### PR TITLE
fix(did-resolver): always include didResolutionMetadata in result

### DIFF
--- a/__tests__/shared/resolveDid.ts
+++ b/__tests__/shared/resolveDid.ts
@@ -23,16 +23,18 @@ export default (testContext: {
       expect(didDoc?.id).toEqual(didUrl)
     })
 
-    it('should resolve did:key', async () => {
+    it('should resolve did:key github #681', async () => {
       const didUrl = 'did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL'
       const result = await agent.resolveDid({ didUrl })
       const didDoc = result.didDocument
       expect(didDoc?.id).toEqual(didUrl)
+      expect(result).toHaveProperty('didDocumentMetadata')
+      expect(result).toHaveProperty('didResolutionMetadata')
     })
 
     it('should resolve imported fake did', async () => {
       const did = 'did:fake:myfakedid'
-      const importedFakeDID = await agent.didManagerImport({
+      await agent.didManagerImport({
         did,
         keys: [
           {
@@ -56,7 +58,7 @@ export default (testContext: {
       })
       const resolved = await agent.resolveDid({ didUrl: did })
       expect(resolved.didDocument).toEqual({
-        id: 'did:fake:myfakedid',
+        id: did,
         service: [
           {
             id: 'did:fake:myfakedid#fake-service-1',
@@ -77,6 +79,8 @@ export default (testContext: {
         authentication: ['did:fake:myfakedid#fake-key-1'],
         assertionMethod: ['did:fake:myfakedid#fake-key-1'],
       })
+      expect(resolved).toHaveProperty('didDocumentMetadata')
+      expect(resolved).toHaveProperty('didResolutionMetadata')
     })
 
     it('should resolve created fake did', async () => {
@@ -103,6 +107,7 @@ export default (testContext: {
     })
 
     it('should throw error when resolving garbage', async () => {
+      expect.assertions(3)
       //@ts-ignore
       await expect(agent.resolveDid()).resolves.toEqual({
         didDocument: null,
@@ -135,6 +140,7 @@ export default (testContext: {
     afterAll(testContext.tearDown)
 
     it('should throw validation error', async () => {
+      expect.assertions(3)
       //@ts-ignore
       await expect(agent.resolveDid()).rejects.toHaveProperty('name', 'ValidationError')
       //@ts-ignore

--- a/packages/did-comm/src/didcomm.ts
+++ b/packages/did-comm/src/didcomm.ts
@@ -468,15 +468,7 @@ export class DIDComm implements IAgentPlugin {
       throw new Error(`not_supported: return routes not supported yet`)
     }
 
-    const result = await context.agent.resolveDid({ didUrl: `${recipientDidUrl}` })
-    const err = result.didResolutionMetadata.error
-    const msg = result.didResolutionMetadata.message
-    const didDoc = result.didDocument
-    if (!didDoc || err) {
-      throw new Error(
-        `resolver_error: could not resolve DID document for '${recipientDidUrl}': ${err} ${msg}`,
-      )
-    }
+    const didDoc = await resolveDidOrThrow(recipientDidUrl, context)
 
     const services = didDoc.service?.filter(
       (service: any) => service.type === 'DIDCommMessaging',

--- a/packages/did-comm/src/utils.ts
+++ b/packages/did-comm/src/utils.ts
@@ -193,11 +193,11 @@ export async function mapIdentifierKeysToDoc(
   return extendedKeys
 }
 
-export async function resolveDidOrThrow(didUrl: string, context: IAgentContext<IResolver>) {
+export async function resolveDidOrThrow(didUrl: string, context: IAgentContext<IResolver>): Promise<DIDDocument> {
   // TODO: add caching
   const docResult = await context.agent.resolveDid({ didUrl: didUrl })
-  const err = docResult.didResolutionMetadata.error
-  const msg = docResult.didResolutionMetadata.message
+  const err = docResult?.didResolutionMetadata?.error
+  const msg = docResult?.didResolutionMetadata?.message
   const didDocument = docResult.didDocument
   if (!isDefined(didDocument) || err) {
     throw new Error(`not_found: could not resolve DID document for '${didUrl}': ${err} ${msg}`)

--- a/packages/did-resolver/src/resolver.ts
+++ b/packages/did-resolver/src/resolver.ts
@@ -44,7 +44,20 @@ export class DIDResolverPlugin implements IAgentPlugin {
       accept: 'application/did+ld+json',
       ...options,
     }
-    return this.didResolver.resolve(didUrl, resolverOptions)
+    
+    // ensure the required fields are present, even if the resolver is not compliant
+    const cannedResponse: DIDResolutionResult = {
+      didDocumentMetadata: {},
+      didResolutionMetadata: {},
+      didDocument: null,
+    }
+
+    const resolution = await this.didResolver.resolve(didUrl, resolverOptions)
+    
+    return {
+      ...cannedResponse,
+      ...resolution,
+    }
   }
 
   /** {@inheritDoc @veramo/core#IResolver.getDIDComponentById} */


### PR DESCRIPTION
fixes #681

It looks like the did-key resolver we use does not include a `didResolutionMetadata` in the result.

I also deduplicated some code in `sendDidCommMessage` and added some more `null` guards.