### PR TITLE
feat(cli): add command to verify an agent configuration file

### DIFF
--- a/packages/cli/default/default.yml
+++ b/packages/cli/default/default.yml
@@ -4,7 +4,8 @@ constants:
   baseUrl: http://localhost:3332
   port: 3332
   # please use your own X25519 key, this is only an example
-  secretKey: 29739248cad1bd1a0fc4d9b75cd4d2990de535baf5caadfdf8d8f86664aa830c
+  # you can generate a new key by running `veramo config gen-key` in a terminal
+  dbEncryptionKey: 29739248cad1bd1a0fc4d9b75cd4d2990de535baf5caadfdf8d8f86664aa830c
   databaseFile: ./database.sqlite
   methods:
     - keyManagerGetKeyManagementSystems
@@ -206,7 +207,7 @@ keyManager:
                 - $ref: /dbConnection
                 - $require: '@veramo/kms-local#SecretBox'
                   $args:
-                    - $ref: /constants/secretKey
+                    - $ref: /constants/dbEncryptionKey
 
 # DID Manager
 didManager:

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,6 +1,7 @@
 import 'cross-fetch/polyfill'
 import program from 'commander'
 import { SecretBox } from '@veramo/kms-local'
+import { getAgent, getConfig } from './setup'
 const fs = require('fs')
 const { dirname } = require('path')
 
@@ -38,12 +39,47 @@ config
 
 config
   .command('create-secret-key')
+  .alias('gen-key')
+  .alias('key-gen')
   .description('generate secret key')
-  .action(async (raw) => {
+  .option('-q, --quiet', 'Only print the raw key, no instructions', false)
+  .action(async (options) => {
     try {
-      const secretKey = await SecretBox.createSecretKey()
-      console.log(secretKey)
+      const dbEncryptionKey = await SecretBox.createSecretKey()
+      if (options.quiet === true) {
+        console.log(dbEncryptionKey)
+      } else {
+        console.log(`
+        X25519 raw private key (hex encoded):
+  
+        ${dbEncryptionKey}
+  
+        You can use this key with @veramo/kms-local#SecretBox
+        or replace the default agent.yml 'dbEncryptionKey' constant
+        `)
+      }
     } catch (e: any) {
       console.error(e.message)
+    }
+  })
+
+config
+  .command('check')
+  .alias('verify')
+  .description('Verify an agent config file syntax')
+  .option('-f, --filename <string>', 'Config file name', './agent.yml')
+  .option('-m, --method <string>', 'Check that a specific method is exposed by the agent.', 'execute')
+  .action(async (options) => {
+    const agent = getAgent(options.filename)
+    if (!agent) {
+      console.error(
+        'unknown error while creating the agent from your config. Consider running `veramo config create` to generate a new configuration file, or to manually compare differences.',
+      )
+    } else {
+      if (typeof agent[options.method] !== 'function') {
+        console.error(`The agent was created using the config, but the 'agent.${options.method}()' method is not available. Make sure the plugin that implements that method is installed.`)
+      } else {
+        console.log(`Your Veramo configuration seems fine. An agent can be created and the 'agent.${options.method}()' method can be called on it.`)
+      }
     }
   })

--- a/packages/cli/src/dev.ts
+++ b/packages/cli/src/dev.ts
@@ -1,21 +1,16 @@
-import { getAgent } from './setup'
-import program from 'commander'
-const fs = require('fs')
-import { resolve, dirname } from 'path'
-import { writeFileSync, readFileSync } from 'fs'
-import * as TJS from 'ts-json-schema-generator'
-import { JSONSchema7 } from 'json-schema'
-import { OpenAPIV3 } from 'openapi-types'
 import { Extractor, ExtractorConfig, ExtractorResult } from '@microsoft/api-extractor'
 import {
-  ApiModel,
-  ApiPackage,
-  ApiParameterListMixin,
-  ApiDocumentedItem,
-  ApiReturnTypeMixin,
   ApiMethodSignature,
+  ApiModel,
+  ApiParameterListMixin,
+  ApiReturnTypeMixin,
 } from '@microsoft/api-extractor-model'
-import { IIdentifier } from '@veramo/core'
+import program from 'commander'
+import { writeFileSync } from 'fs'
+import { OpenAPIV3 } from 'openapi-types'
+import { resolve } from 'path'
+import * as TJS from 'ts-json-schema-generator'
+const fs = require('fs')
 
 interface Method {
   packageName: string

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -17,7 +17,7 @@ export const getConfig = (fileName: string): any => {
     process.exit(1)
   }
 
-  const config = yaml.parse(fs.readFileSync(fileName).toString())
+  const config = yaml.parse(fs.readFileSync(fileName).toString(), { prettyErrors: true })
 
   if (config?.version != 3) {
     console.log('Unsupported configuration file version:', config.version)


### PR DESCRIPTION
Run `veramo config check` in a terminal to check that the `agent.yml` syntax is correct and that an agent can be created from it.
In case of YML errors, the problematic line is indicated.

You can check for a different file using the `-f` option and also verify that a particular method can be called on the created agent using the `-m` option.

I also added some aliases and a more descriptive output to the `veramo config create-secret-key` command.