### PR TITLE
hotfix(cli): fix credential verify command for JWT credentials

### DIFF
--- a/packages/cli/src/credential.ts
+++ b/packages/cli/src/credential.ts
@@ -179,19 +179,14 @@ credential
     } else {
       raw = await readStdin()
     }
-    let credentialAsJSON: any
+    let parsedCredential: any
     try {
-      credentialAsJSON = json5.parse(raw)
+      parsedCredential = json5.parse(raw)
     } catch (e: any) {
-      credentialAsJSON = {
-        proof: {
-          type: 'JwtProof2020',
-          jwt: raw,
-        },
-      } as any
+      parsedCredential = raw
     }
     try {
-      const result = await agent.verifyCredential({ credential: credentialAsJSON })
+      const result = await agent.verifyCredential({ credential: parsedCredential })
       if (result.verified === true) {
         console.log('Credential was verified successfully.')
       } else {

--- a/packages/credential-w3c/src/action-handler.ts
+++ b/packages/credential-w3c/src/action-handler.ts
@@ -291,7 +291,7 @@ export class CredentialPlugin implements IAgentPlugin {
         verifiedCredential = verificationResult.verifiableCredential
 
         // if credential was presented with other fields, make sure those fields match what's in the JWT
-        if (typeof credential !== 'string') {
+        if (typeof credential !== 'string' && credential.proof.type === 'JwtProof2020') {
           const credentialCopy = JSON.parse(JSON.stringify(credential))
           delete credentialCopy.proof.jwt
 
@@ -300,7 +300,9 @@ export class CredentialPlugin implements IAgentPlugin {
 
           if (canonicalize(credentialCopy) !== canonicalize(verifiedCopy)) {
             verificationResult.verified = false
-            verificationResult.error = new Error('Credential does not match JWT')
+            verificationResult.error = new Error(
+              'invalid_credential: Credential JSON does not match JWT payload',
+            )
           }
         }
       } catch (e: any) {


### PR DESCRIPTION
## What issue is this PR fixing

This is a hotfix for a bug in the `@veramo/cli` package that is preventing proper credential verification for JWT-VC.

## What is being changed

`@veramo/cli credential verify` command would try to parse a JWT credential and coerce it into a JSON format without doing the same kind of parsing that `did-jwt-vc` would do when verifying.
This caused the `@veramo/credential-w3c` package to then refuse the verification because of the mismatch between the JSON and the JWT payload.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.