### PR TITLE
fix import json5 for the cli credential verify

### DIFF
--- a/packages/cli/src/credential.ts
+++ b/packages/cli/src/credential.ts
@@ -3,7 +3,7 @@ import { Command } from 'commander'
 import inquirer from 'inquirer'
 import qrcode from 'qrcode-terminal'
 import * as fs from 'fs'
-import * as json5 from 'json5'
+import json5 from 'json5'
 import { readStdin } from './util.js'
 import { CredentialPayload } from '@veramo/core-types'
 


### PR DESCRIPTION
## What issue is this PR fixing
Fix the issue when run `veramo credential verify --filename test.json` that will raise an error `TypeError: json5.parse is not a function`

## What is being changed
Change the import json5

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [x] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.

