### PR TITLE
feat(credential-w3c): list usable proof formats for an `IIdentifier`

### DIFF
--- a/__tests__/localAgent.test.ts
+++ b/__tests__/localAgent.test.ts
@@ -7,9 +7,7 @@
  * This suite also runs a ganache local blockchain to run through some examples of DIDComm using did:ethr identifiers.
  */
 
-import {
-  createAgent,
-} from '../packages/core/src'
+import { createAgent } from '../packages/core/src'
 import {
   IAgentOptions,
   ICredentialPlugin,
@@ -91,8 +89,9 @@ import didCommWithEthrDidFlow from './shared/didCommWithEthrDidFlow'
 import utils from './shared/utils'
 import web3 from './shared/web3'
 import credentialStatus from './shared/credentialStatus'
-import ethrDidFlowSigned from "./shared/ethrDidFlowSigned";
+import ethrDidFlowSigned from './shared/ethrDidFlowSigned'
 import didCommWithPeerDidFlow from './shared/didCommWithPeerDidFlow.js'
+import credentialPluginTests from './shared/credentialPluginTests.js'
 
 jest.setTimeout(120000)
 
@@ -117,8 +116,7 @@ let dbConnection: Promise<DataSource>
 let databaseFile: string
 
 const setup = async (options?: IAgentOptions): Promise<boolean> => {
-  databaseFile =
-    options?.context?.databaseFile || ':memory:'
+  databaseFile = options?.context?.databaseFile || ':memory:'
   dbConnection = new DataSource({
     name: options?.context?.['dbName'] || 'test',
     type: 'sqlite',
@@ -202,7 +200,7 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
             defaultKms: 'local',
           }),
           'did:peer': new PeerDIDProvider({
-            defaultKms: 'local'
+            defaultKms: 'local',
           }),
           'did:pkh': new PkhDIDProvider({
             defaultKms: 'local',
@@ -303,4 +301,5 @@ describe('Local integration tests', () => {
   didCommWithPeerDidFlow(testContext)
   credentialStatus(testContext)
   ethrDidFlowSigned(testContext)
+  credentialPluginTests(testContext)
 })

--- a/__tests__/localJsonStoreAgent.test.ts
+++ b/__tests__/localJsonStoreAgent.test.ts
@@ -76,6 +76,7 @@ import messageHandler from './shared/messageHandler'
 import utils from './shared/utils'
 import { JsonFileStore } from './utils/json-file-store'
 import credentialStatus from './shared/credentialStatus'
+import credentialPluginTests from './shared/credentialPluginTests'
 
 jest.setTimeout(120000)
 
@@ -241,4 +242,5 @@ describe('Local json-data-store integration tests', () => {
   didCommPacking(testContext)
   utils(testContext)
   credentialStatus(testContext)
+  credentialPluginTests(testContext)
 })

--- a/__tests__/localMemoryStoreAgent.test.ts
+++ b/__tests__/localMemoryStoreAgent.test.ts
@@ -72,6 +72,7 @@ import messageHandler from './shared/messageHandler.js'
 import utils from './shared/utils.js'
 import credentialStatus from './shared/credentialStatus.js'
 import credentialInterop from './shared/credentialInterop.js'
+import credentialPluginTests from "./shared/credentialPluginTests.js";
 
 jest.setTimeout(120000)
 
@@ -239,4 +240,5 @@ describe('Local in-memory integration tests', () => {
   utils(testContext)
   credentialStatus(testContext)
   credentialInterop(testContext)
+  credentialPluginTests(testContext)
 })

--- a/__tests__/restAgent.test.ts
+++ b/__tests__/restAgent.test.ts
@@ -99,6 +99,7 @@ import messageHandler from './shared/messageHandler'
 import didDiscovery from './shared/didDiscovery'
 import utils from './shared/utils'
 import credentialStatus from './shared/credentialStatus'
+import credentialPluginTests from "./shared/credentialPluginTests";
 
 jest.setTimeout(120000)
 
@@ -303,4 +304,5 @@ describe('REST integration tests', () => {
   didDiscovery(testContext)
   utils(testContext)
   credentialStatus(testContext)
+  credentialPluginTests(testContext)
 })

--- a/__tests__/shared/credentialPluginTests.ts
+++ b/__tests__/shared/credentialPluginTests.ts
@@ -1,0 +1,88 @@
+// noinspection ES6PreferShortImport
+
+import { IAgentOptions, ICredentialPlugin, MinimalImportableKey, TAgent } from '../../packages/core-types/src'
+
+type ConfiguredAgent = TAgent<ICredentialPlugin>
+export default (testContext: {
+  getAgent: (options?: IAgentOptions) => ConfiguredAgent
+  setup: (options?: IAgentOptions) => Promise<boolean>
+  tearDown: () => Promise<boolean>
+}) => {
+  describe('credential plugin options', () => {
+    let agent: ConfiguredAgent
+
+    beforeAll(async () => {
+      await testContext.setup()
+      agent = testContext.getAgent()
+      return true
+    })
+    afterAll(testContext.tearDown)
+
+    it('should list signing options for did:key with Ed25519 key', async () => {
+      const iid = await agent.didManagerCreate({
+        provider: 'did:key',
+        kms: 'local',
+        options: {
+          keyType: 'Ed25519',
+        },
+      })
+
+      const options = await agent.listUsableProofFormats(iid)
+      expect(options).toEqual(['jwt', 'lds'])
+    })
+
+    it('should list signing options for did:key with Secp256k1 key', async () => {
+      const iid = await agent.didManagerCreate({
+        provider: 'did:key',
+        kms: 'local',
+        options: {
+          keyType: 'Secp256k1',
+        },
+      })
+
+      const options = await agent.listUsableProofFormats(iid)
+      expect(options).toEqual(['jwt', 'lds', 'EthereumEip712Signature2021'])
+    })
+
+    it('should list signing options for did:key with X25519 key', async () => {
+      const iid = await agent.didManagerCreate({
+        provider: 'did:key',
+        kms: 'local',
+        options: {
+          keyType: 'X25519',
+        },
+      })
+
+      const options = await agent.listUsableProofFormats(iid)
+      expect(options).toEqual([])
+    })
+
+    it('should list signing options for did:ethr with web3 backed keys', async () => {
+      const account = `0x71CB05EE1b1F506fF321Da3dac38f25c0c9ce6E1`
+      const did = `did:ethr:${account}`
+      const controllerKeyId = `ethers-${account}`
+      const iid = await agent.didManagerImport({
+        did,
+        provider: 'did:ethr',
+        controllerKeyId,
+        keys: [
+          {
+            kid: controllerKeyId,
+            type: 'Secp256k1',
+            kms: 'web3',
+            privateKeyHex: '',
+            publicKeyHex: '',
+            meta: {
+              account,
+              provider: 'ethers',
+              algorithms: ['eth_signMessage', 'eth_signTypedData'],
+            },
+          } as MinimalImportableKey,
+        ],
+      })
+
+      const options = await agent.listUsableProofFormats(iid)
+      expect(options).toEqual(['EthereumEip712Signature2021'])
+    })
+  })
+}

--- a/packages/core-types/src/plugin.schema.json
+++ b/packages/core-types/src/plugin.schema.json
@@ -4208,7 +4208,7 @@
             "save": {
               "type": "boolean",
               "description": "If this parameter is true, the resulting VerifiablePresentation is sent to the\n {@link  @veramo/core-types#IDataStore | storage plugin }  to be saved.",
-              "deprecated": "Please call\n{@link @veramo/core-types#IDataStore.dataStoreSaveVerifiableCredential | dataStoreSaveVerifiableCredential()} to save\nthe credential after creating it."
+              "deprecated": "Please call\n{@link @veramo/core-types#IDataStore.dataStoreSaveVerifiableCredential | dataStoreSaveVerifiableCredential()} to\nsave the credential after creating it."
             },
             "proofFormat": {
               "$ref": "#/components/schemas/ProofFormat",
@@ -4422,7 +4422,7 @@
             "save": {
               "type": "boolean",
               "description": "If this parameter is true, the resulting VerifiablePresentation is sent to the\n {@link  @veramo/core-types#IDataStore | storage plugin }  to be saved. <p/><p/>",
-              "deprecated": "Please call\n{@link @veramo/core-types#IDataStore.dataStoreSaveVerifiablePresentation | dataStoreSaveVerifiablePresentation()} to\nsave the credential after creating it."
+              "deprecated": "Please call\n{@link @veramo/core-types#IDataStore.dataStoreSaveVerifiablePresentation |}   *   dataStoreSaveVerifiablePresentation()} to save the credential after creating it."
             },
             "challenge": {
               "type": "string",
@@ -4568,6 +4568,167 @@
             "proof"
           ],
           "description": "Represents a signed Verifiable Presentation (includes proof), using a JSON representation. See  {@link  https://www.w3.org/TR/vc-data-model/#presentations | VP data model }"
+        },
+        "IIdentifier": {
+          "type": "object",
+          "properties": {
+            "did": {
+              "type": "string",
+              "description": "Decentralized identifier"
+            },
+            "alias": {
+              "type": "string",
+              "description": "Optional. Identifier alias. Can be used to reference an object in an external system"
+            },
+            "provider": {
+              "type": "string",
+              "description": "Identifier provider name"
+            },
+            "controllerKeyId": {
+              "type": "string",
+              "description": "Controller key id"
+            },
+            "keys": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/IKey"
+              },
+              "description": "Array of managed keys"
+            },
+            "services": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/IService"
+              },
+              "description": "Array of services"
+            }
+          },
+          "required": [
+            "did",
+            "provider",
+            "keys",
+            "services"
+          ],
+          "description": "Identifier interface"
+        },
+        "IKey": {
+          "type": "object",
+          "properties": {
+            "kid": {
+              "type": "string",
+              "description": "Key ID"
+            },
+            "kms": {
+              "type": "string",
+              "description": "Key Management System"
+            },
+            "type": {
+              "$ref": "#/components/schemas/TKeyType",
+              "description": "Key type"
+            },
+            "publicKeyHex": {
+              "type": "string",
+              "description": "Public key"
+            },
+            "privateKeyHex": {
+              "type": "string",
+              "description": "Optional. Private key"
+            },
+            "meta": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/KeyMetadata"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional. Key metadata. This should be used to determine which algorithms are supported."
+            }
+          },
+          "required": [
+            "kid",
+            "kms",
+            "type",
+            "publicKeyHex"
+          ],
+          "description": "Cryptographic key, usually managed by the current Veramo instance."
+        },
+        "TKeyType": {
+          "type": "string",
+          "enum": [
+            "Ed25519",
+            "Secp256k1",
+            "Secp256r1",
+            "X25519",
+            "Bls12381G1",
+            "Bls12381G2"
+          ],
+          "description": "Cryptographic key type."
+        },
+        "KeyMetadata": {
+          "type": "object",
+          "properties": {
+            "algorithms": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/TAlg"
+              }
+            }
+          },
+          "description": "This encapsulates data about a key.\n\nImplementations of  {@link  @veramo/key-manager#AbstractKeyManagementSystem | AbstractKeyManagementSystem }  should populate this object, for each key, with the algorithms that can be performed using it.\n\nThis can also be used to add various tags to the keys under management."
+        },
+        "TAlg": {
+          "type": "string",
+          "description": "Known algorithms supported by some of the above key types defined by  {@link  TKeyType } .\n\nActual implementations of  {@link  @veramo/key-manager#AbstractKeyManagementSystem | Key Management Systems }  can support more. One should check the  {@link IKey.meta | IKey.meta.algorithms }  property to see what is possible for a particular managed key."
+        },
+        "IService": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "ID"
+            },
+            "type": {
+              "type": "string",
+              "description": "Service type"
+            },
+            "serviceEndpoint": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/IServiceEndpoint"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/IServiceEndpoint"
+                  }
+                }
+              ],
+              "description": "Endpoint URL"
+            },
+            "description": {
+              "type": "string",
+              "description": "Optional. Description"
+            }
+          },
+          "required": [
+            "id",
+            "type",
+            "serviceEndpoint"
+          ],
+          "description": "Identifier service"
+        },
+        "IServiceEndpoint": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
+          ],
+          "description": "Represents a service endpoint URL or a map of URLs"
         }
       },
       "methods": {
@@ -4587,6 +4748,18 @@
           },
           "returnType": {
             "$ref": "#/components/schemas/VerifiablePresentation"
+          }
+        },
+        "listUsableProofFormats": {
+          "description": "Returns a list of supported proof formats.",
+          "arguments": {
+            "$ref": "#/components/schemas/IIdentifier"
+          },
+          "returnType": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProofFormat"
+            }
           }
         }
       }

--- a/packages/core-types/src/types/ICredentialIssuer.ts
+++ b/packages/core-types/src/types/ICredentialIssuer.ts
@@ -9,6 +9,7 @@ import { IResolver } from './IResolver.js'
 import { IDIDManager } from './IDIDManager.js'
 import { IDataStore } from './IDataStore.js'
 import { IKeyManager } from './IKeyManager.js'
+import { IIdentifier, IKey } from "./IIdentifier.js";
 
 /**
  * The type of encoding to be used for the Verifiable Credential or Presentation to be generated.
@@ -42,8 +43,8 @@ export interface ICreateVerifiablePresentationArgs {
    * {@link @veramo/core-types#IDataStore | storage plugin} to be saved.
    * <p/><p/>
    * @deprecated Please call
-   *   {@link @veramo/core-types#IDataStore.dataStoreSaveVerifiablePresentation | dataStoreSaveVerifiablePresentation()} to
-   *   save the credential after creating it.
+   *   {@link @veramo/core-types#IDataStore.dataStoreSaveVerifiablePresentation |
+   *   dataStoreSaveVerifiablePresentation()} to save the credential after creating it.
    */
   save?: boolean
 
@@ -113,8 +114,8 @@ export interface ICreateVerifiableCredentialArgs {
    * {@link @veramo/core-types#IDataStore | storage plugin} to be saved.
    *
    * @deprecated Please call
-   *   {@link @veramo/core-types#IDataStore.dataStoreSaveVerifiableCredential | dataStoreSaveVerifiableCredential()} to save
-   *   the credential after creating it.
+   *   {@link @veramo/core-types#IDataStore.dataStoreSaveVerifiableCredential | dataStoreSaveVerifiableCredential()} to
+   *   save the credential after creating it.
    */
   save?: boolean
 
@@ -191,8 +192,8 @@ export interface ICredentialIssuer extends IPluginMethodMap {
    * @param args - Arguments necessary to create the Presentation.
    * @param context - This reserved param is automatically added and handled by the framework, *do not override*
    *
-   * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiableCredential} that was requested or rejects
-   *   with an error if there was a problem with the input or while getting the key to sign
+   * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiableCredential} that was requested or
+   *   rejects with an error if there was a problem with the input or while getting the key to sign
    *
    * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#credentials | Verifiable Credential data model}
    */
@@ -200,6 +201,24 @@ export interface ICredentialIssuer extends IPluginMethodMap {
     args: ICreateVerifiableCredentialArgs,
     context: IssuerAgentContext,
   ): Promise<VerifiableCredential>
+
+  /**
+   * Returns a list of supported proof formats.
+   * @param identifier - The identifier that may be used to sign a credential or presentation
+   * @param context - This reserved param is automatically added and handled by the framework, *do not override*
+   *
+   * @beta This API may change without a BREAKING CHANGE notice.
+   */
+  listUsableProofFormats(identifier: IIdentifier, context: IAgentContext<{}>): Promise<Array<ProofFormat>>
+
+  /**
+   * Checks if a key is suitable for signing JWT payloads.
+   * @param key - the key to check for compatibility
+   * @param context - This reserved param is automatically added and handled by the framework, *do not override*
+   *
+   * @internal
+   */
+  matchKeyForJWT(key: IKey, context: IAgentContext<any>): Promise<boolean>
 }
 
 /**
@@ -212,7 +231,7 @@ export interface ICredentialIssuer extends IPluginMethodMap {
  */
 export type IssuerAgentContext = IAgentContext<
   IResolver &
-    Pick<IDIDManager, 'didManagerGet' | 'didManagerFind'> &
-    Pick<IDataStore, 'dataStoreSaveVerifiablePresentation' | 'dataStoreSaveVerifiableCredential'> &
-    Pick<IKeyManager, 'keyManagerGet' | 'keyManagerSign'>
+  Pick<IDIDManager, 'didManagerGet' | 'didManagerFind'> &
+  Pick<IDataStore, 'dataStoreSaveVerifiablePresentation' | 'dataStoreSaveVerifiableCredential'> &
+  Pick<IKeyManager, 'keyManagerGet' | 'keyManagerSign'>
 >

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -29,7 +29,7 @@ const filterUnauthorizedMethods = (
 /**
  * Provides a common context for all plugin methods.
  *
- * This is the main entry point into the API of the DID Agent Framework.
+ * This is the main entry point into the API of Veramo.
  * When plugins are installed, they extend the API of the agent and the methods
  * they provide can all use the common context so that plugins can build on top
  * of each other and create a richer experience.

--- a/packages/credential-eip712/src/types/ICredentialEIP712.ts
+++ b/packages/credential-eip712/src/types/ICredentialEIP712.ts
@@ -2,6 +2,7 @@ import {
   CredentialPayload,
   IAgentContext,
   IDIDManager,
+  IKey,
   IKeyManager,
   IPluginMethodMap,
   IResolver,
@@ -15,7 +16,8 @@ import {
  * that use EIP712 proof format.
  *
  * @remarks Please see {@link https://www.w3.org/TR/vc-data-model | W3C Verifiable Credentials data model}
- * @remarks Please see {@link https://w3c-ccg.github.io/ethereum-eip712-signature-2021-spec/ | EthereumEip712Signature2021}
+ * @remarks Please see
+ *   {@link https://w3c-ccg.github.io/ethereum-eip712-signature-2021-spec/ | EthereumEip712Signature2021}
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
@@ -27,8 +29,8 @@ export interface ICredentialIssuerEIP712 extends IPluginMethodMap {
    * @param args - Arguments necessary to create the Credential.
    * @param context - This reserved param is automatically added and handled by the framework, *do not override*
    *
-   * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiableCredential} that was requested or rejects with an error
-   * if there was a problem with the input or while getting the key to sign
+   * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiableCredential} that was requested or
+   *   rejects with an error if there was a problem with the input or while getting the key to sign
    *
    * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#credentials | Verifiable Credential data model}
    *
@@ -60,10 +62,11 @@ export interface ICredentialIssuerEIP712 extends IPluginMethodMap {
    * @param args - Arguments necessary to create the Presentation.
    * @param context - This reserved param is automatically added and handled by the framework, *do not override*
    *
-   * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiablePresentation} that was requested or rejects with an error
-   * if there was a problem with the input or while getting the key to sign
+   * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiablePresentation} that was requested or
+   *   rejects with an error if there was a problem with the input or while getting the key to sign
    *
-   * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#presentations | Verifiable Presentation data model }
+   * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#presentations | Verifiable Presentation data model
+   *   }
    */
   createVerifiablePresentationEIP712(
     args: ICreateVerifiablePresentationEIP712Args,
@@ -81,6 +84,17 @@ export interface ICredentialIssuerEIP712 extends IPluginMethodMap {
    * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#presentations | Verifiable Credential data model}
    */
   verifyPresentationEIP712(args: IVerifyPresentationEIP712Args, context: IRequiredContext): Promise<boolean>
+
+  /**
+   * Checks if a key is suitable for signing EIP712 payloads.
+   * This relies on the metadata set by the key management system to determine if this key can sign EIP712 payloads.
+   *
+   * @param key - the key to check
+   * @param context - This reserved param is automatically added and handled by the framework, *do not override*
+   *
+   * @internal
+   */
+  matchKeyForEIP712(key: IKey, context: IRequiredContext): Promise<boolean>
 }
 
 /**

--- a/packages/credential-ld/src/types.ts
+++ b/packages/credential-ld/src/types.ts
@@ -2,6 +2,7 @@ import {
   CredentialPayload,
   IAgentContext,
   IDIDManager,
+  IKey,
   IKeyManager,
   IPluginMethodMap,
   IResolver,
@@ -27,10 +28,11 @@ export interface ICredentialIssuerLD extends IPluginMethodMap {
    * @param args - Arguments necessary to create the Presentation.
    * @param context - This reserved param is automatically added and handled by the framework, *do not override*
    *
-   * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiablePresentation} that was requested or rejects with an error
-   * if there was a problem with the input or while getting the key to sign
+   * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiablePresentation} that was requested or
+   *   rejects with an error if there was a problem with the input or while getting the key to sign
    *
-   * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#presentations | Verifiable Presentation data model }
+   * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#presentations | Verifiable Presentation data model
+   *   }
    *
    * @beta This API may change without a BREAKING CHANGE notice.
    */
@@ -46,8 +48,8 @@ export interface ICredentialIssuerLD extends IPluginMethodMap {
    * @param args - Arguments necessary to create the Presentation.
    * @param context - This reserved param is automatically added and handled by the framework, *do not override*
    *
-   * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiableCredential} that was requested or rejects with an error
-   * if there was a problem with the input or while getting the key to sign
+   * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiableCredential} that was requested or
+   *   rejects with an error if there was a problem with the input or while getting the key to sign
    *
    * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#credentials | Verifiable Credential data model}
    *
@@ -85,6 +87,15 @@ export interface ICredentialIssuerLD extends IPluginMethodMap {
    * @beta This API may change without a BREAKING CHANGE notice.
    */
   verifyPresentationLD(args: IVerifyPresentationLDArgs, context: IRequiredContext): Promise<boolean>
+
+  /**
+   * Returns true if the key is supported by any of the installed LD Signature suites
+   * @param key - the key to verify
+   * @param context - This reserved param is automatically added and handled by the framework, *do not override*
+   *
+   * @internal
+   */
+  matchKeyForLDSuite(key: IKey, context: IAgentContext<{}>): Promise<boolean>
 }
 
 /**

--- a/packages/credential-w3c/src/__tests__/message-handler.test.ts
+++ b/packages/credential-w3c/src/__tests__/message-handler.test.ts
@@ -1,4 +1,4 @@
-import { DIDResolutionResult, IAgentContext, ICredentialPlugin, IResolver } from '../../../core-types/src'
+import { DIDResolutionResult, IAgentContext, ICredentialVerifier, IResolver } from '../../../core-types/src'
 import { Message } from '../../../message-handler/src'
 import { IContext, MessageTypes, W3cMessageHandler } from '../message-handler.js'
 import { jest } from '@jest/globals'
@@ -64,13 +64,11 @@ describe('@veramo/credential-w3c', () => {
           }
         }
       },
-      createVerifiableCredential: jest.fn(),
-      createVerifiablePresentation: jest.fn(),
       verifyCredential: jest.fn(),
       verifyPresentation: jest.fn(),
       getDIDComponentById: jest.fn(),
     },
-  } as IAgentContext<IResolver & ICredentialPlugin>
+  } as IAgentContext<IResolver & ICredentialVerifier>
 
   it('should reject unknown message type', async () => {
     expect.assertions(1)


### PR DESCRIPTION
## What is being changed

The `CredentialPlugin` now exports a new method `listUsableProofFormats()` that can be used to decide which type of `proofFormat` can be requested for creating a credential or presentation.
It queries the other available credential plugins to check if the keys of a DID are usable with them and also relies on the metadata provided by key management systems in its decision.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [X] I added integration tests.
