### PR TITLE
fix(data-store-json): order credentials with weird issuanceDate

### DIFF
--- a/packages/data-store-json/src/data-store-json.ts
+++ b/packages/data-store-json/src/data-store-json.ts
@@ -599,7 +599,9 @@ function buildQuery<T extends Partial<Record<PossibleColumns, any>>>(
         const colA = a[col]
         const colB = b[col]
         if (typeof colA?.getTime === 'function') {
-          result = direction * (colA.getTime() - colB.getTime() || 0)
+          const aTime = colA.getTime()
+          const bTime = typeof colB?.getTime === 'function' ? colB.getTime() : 0
+          result = direction * (aTime - bTime || 0)
         } else if (typeof colA?.localeCompare === 'function') {
           result = direction * colA.localeCompare(colB)
         } else {


### PR DESCRIPTION
## What is being changed
Some credentials from the wild are missing an `issuanceDate`, or have the date in a non-parseable format.
This fix defaults their date to unixtime(0) when compared to other credentials for database sorting.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because only the `data-store-json` plugin accepts undefined `issuanceDate`.

## Details
I added #1274 to demonstrate how a test for this might look like, but it would introduce a breaking change (if people use their own migrations)
