### PR TITLE
fix(data-store): support credentials with undefined `issuanceDate`

### DIFF
--- a/__tests__/localAgent.test.ts
+++ b/__tests__/localAgent.test.ts
@@ -264,7 +264,7 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
 const tearDown = async (): Promise<boolean> => {
   try {
     await (await dbConnection).dropDatabase()
-    await (await dbConnection).close()
+    await (await dbConnection).destroy()
   } catch (e) {
     // nop
   }

--- a/__tests__/localMemoryStoreAgent.test.ts
+++ b/__tests__/localMemoryStoreAgent.test.ts
@@ -213,6 +213,7 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
 
 const tearDown = async (): Promise<boolean> => {
   try {
+    await dbConnection?.dropDatabase()
     await dbConnection?.destroy()
   } catch (e) {
     // nop

--- a/__tests__/restAgent.test.ts
+++ b/__tests__/restAgent.test.ts
@@ -273,7 +273,7 @@ const tearDown = async (): Promise<boolean> => {
   await new Promise((resolve, reject) => restServer.close(resolve))
   try {
     await (await dbConnection).dropDatabase()
-    await (await dbConnection).close()
+    await (await dbConnection).destroy()
   } catch (e) {
     // nop
   }

--- a/packages/data-store/src/entities/claim.ts
+++ b/packages/data-store/src/entities/claim.ts
@@ -36,9 +36,10 @@ export class Claim extends BaseEntity {
   // @ts-ignore
   credential: Relation<Credential>
 
-  @Column()
+  // The VC data model does not allow credentials without an issuance date, but some credentials from the wild may
+  @Column({ nullable: true })
   // @ts-ignore
-  issuanceDate: Date
+  issuanceDate?: Date
 
   @Column({ nullable: true })
   expirationDate?: Date

--- a/packages/data-store/src/entities/credential.ts
+++ b/packages/data-store/src/entities/credential.ts
@@ -18,8 +18,7 @@ import { asArray, computeEntryHash, extractIssuer } from '@veramo/utils'
 /**
  * Represents some common properties of a Verifiable Credential that are stored in a TypeORM database for querying.
  *
- * @see {@link @veramo/core-types#IDataStoreORM.dataStoreORMGetVerifiableCredentials | dataStoreORMGetVerifiableCredentials}
- *   for the interface defining how this can be queried.
+ * @see {@link @veramo/core-types#IDataStoreORM.dataStoreORMGetVerifiableCredentials | dataStoreORMGetVerifiableCredentials} for the interface defining how this can be queried.
  *
  * @see {@link @veramo/data-store#DataStoreORM | DataStoreORM} for the implementation of the query interface.
  *
@@ -65,9 +64,10 @@ export class Credential extends BaseEntity {
   @Column({ nullable: true })
   id?: string
 
-  @Column()
+  // The VC data model does not allow credentials without an issuance date, but some credentials from the wild may
+  @Column({ nullable: true })
   // @ts-ignore
-  issuanceDate: Date
+  issuanceDate?: Date
 
   @Column({ nullable: true })
   expirationDate?: Date

--- a/packages/data-store/src/migrations/5.allowNullVCIssuanceDate.ts
+++ b/packages/data-store/src/migrations/5.allowNullVCIssuanceDate.ts
@@ -1,0 +1,116 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+import { Claim, Credential } from '../index.js'
+import Debug from 'debug'
+import { migrationGetExistingTableByName } from './migration-functions.js'
+
+const debug = Debug('veramo:data-store:migrate-credentials-issuance-date')
+
+/**
+ * Reduce issuanceDate constraint of Credential and Claim entities.
+ *
+ * @public
+ */
+export class AllowNullIssuanceDateForCredentials1697194289809 implements MigrationInterface {
+  name = 'AllowNullIssuanceDateForCredentials1697194289809' // Used in case this class gets minified, which would
+  // change the classname
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    if (queryRunner.connection.driver.options.type === 'sqlite') {
+      debug(`splitting migration into multiple transactions to allow sqlite table updates`)
+      await queryRunner.commitTransaction()
+      debug(`turning off foreign keys`)
+      await queryRunner.query('PRAGMA foreign_keys=off')
+      await queryRunner.startTransaction()
+    }
+
+    // update issuanceDate column for credentials
+    {
+      const table = migrationGetExistingTableByName(queryRunner, 'credential')
+      const oldColumn = table?.findColumnByName('issuanceDate')!
+      const newColumn = oldColumn.clone()
+      newColumn.isNullable = true
+      debug(`updating issuanceDate for credentials to allow null`)
+      await queryRunner.changeColumn(table!, oldColumn, newColumn)
+      debug(`updated issuanceDate for credentials to allow null`)
+    }
+
+    // update issuanceDate column for claims
+    {
+      const table = migrationGetExistingTableByName(queryRunner, 'claim')
+      const oldColumn = table?.findColumnByName('issuanceDate')!
+      const newColumn = oldColumn.clone()
+      newColumn.isNullable = true
+      debug(`updating issuanceDate for credential claims to allow null`)
+      await queryRunner.changeColumn(table!, oldColumn, newColumn)
+      debug(`updated issuanceDate for credential claims to allow null`)
+    }
+
+    if (queryRunner.connection.driver.options.type === 'sqlite') {
+      debug(`splitting migration into multiple transactions to allow sqlite table updates`)
+      await queryRunner.commitTransaction()
+      debug(`turning on foreign keys`)
+      await queryRunner.query('PRAGMA foreign_keys=on')
+      await queryRunner.startTransaction()
+    }
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    if (queryRunner.connection.driver.options.type === 'sqlite') {
+      debug(`splitting migration into multiple transactions to allow sqlite table updates`)
+      await queryRunner.commitTransaction()
+      debug(`turning off foreign keys`)
+      await queryRunner.query('PRAGMA foreign_keys=off')
+      await queryRunner.startTransaction()
+    }
+
+    // update issuanceDate column for credential table
+    {
+      const table = migrationGetExistingTableByName(queryRunner, 'credential')
+      debug(`DOWN update NULL 'issuanceDate' with FAKE data for '${table.name}' table`)
+      await queryRunner.manager
+        .createQueryBuilder()
+        .update(Credential)
+        .set({ issuanceDate: new Date(0) })
+        .where('issuanceDate is NULL')
+        .execute()
+      // update issuanceDate column
+
+      const oldColumn = table?.findColumnByName('issuanceDate')!
+      const newColumn = oldColumn.clone()
+      newColumn.isNullable = false
+      debug(`updating issuanceDate for credentials to NOT allow null`)
+      await queryRunner.changeColumn(table!, oldColumn, newColumn)
+      debug(`updated issuanceDate for credentials to NOT allow null`)
+    }
+
+    // update issuanceDate for claim table
+    {
+      const table = migrationGetExistingTableByName(queryRunner, 'claim')
+      debug(`DOWN update NULL 'issuanceDate' with FAKE data for '${table.name}' table`)
+      await queryRunner.manager
+        .createQueryBuilder()
+        .update(Claim)
+        .set({ issuanceDate: new Date(0) })
+        .where('issuanceDate is NULL')
+        .execute()
+      // update issuanceDate column
+
+      const oldColumn = table?.findColumnByName('issuanceDate')!
+      const newColumn = oldColumn.clone()
+      newColumn.isNullable = false
+      debug(`updating issuanceDate for credential claims to NOT allow null`)
+      await queryRunner.changeColumn(table!, oldColumn, newColumn)
+      debug(`updated issuanceDate for credential claims to NOT allow null`)
+    }
+
+    if (queryRunner.connection.driver.options.type === 'sqlite') {
+      debug(`splitting migration into multiple transactions to allow sqlite table updates`)
+      await queryRunner.commitTransaction()
+      debug(`turning on foreign keys`)
+      await queryRunner.query('PRAGMA foreign_keys=on')
+      await queryRunner.startTransaction()
+    }
+
+    debug(`DOWN updated issuanceDate for credentials to NOT allow null`)
+  }
+}

--- a/packages/data-store/src/migrations/index.ts
+++ b/packages/data-store/src/migrations/index.ts
@@ -2,6 +2,7 @@ import { CreateDatabase1447159020001 } from './1.createDatabase.js'
 import { SimplifyRelations1447159020002 } from './2.simplifyRelations.js'
 import { CreatePrivateKeyStorage1629293428674 } from './3.createPrivateKeyStorage.js'
 import { AllowNullIssuanceDateForPresentations1637237492913 } from './4.allowNullVPIssuanceDate.js'
+import { AllowNullIssuanceDateForCredentials1697194289809 } from './5.allowNullVCIssuanceDate.js'
 
 
 /**
@@ -24,4 +25,5 @@ export const migrations = [
   SimplifyRelations1447159020002,
   CreatePrivateKeyStorage1629293428674,
   AllowNullIssuanceDateForPresentations1637237492913,
+  AllowNullIssuanceDateForCredentials1697194289809
 ]


### PR DESCRIPTION
## What is being changed

BREAKING CHANGE: this changes the NULL constraints in the `claim` and `credential` table for the `issuanceDate` column, requiring a migration. A migration has been added to the default migration set provided by Veramo, but it is otherwise a breaking change if you are not using that set.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [X] I added integration tests.

## Details
I'm not sure we should be accepting VCs that don't (adhere to the data model](https://www.w3.org/TR/vc-data-model/#issuance-date).
I'm posting this here as a continuation of #1273
