### PR TITLE
fix(data-store-orm): remove double entries

### DIFF
--- a/packages/data-store/src/__tests__/data-store-orm.test.ts
+++ b/packages/data-store/src/__tests__/data-store-orm.test.ts
@@ -264,7 +264,7 @@ describe('@veramo/data-store queries', () => {
     expect(credentials.length).toBe(1)
     expect(credentials[0].verifiableCredential.id).toBe('vc1')
     const count = await makeAgent().dataStoreORMGetVerifiableCredentialsByClaimsCount({})
-    expect(count).toBe(1)
+    expect(count).toBe(3)
 
     const credentials2 = await makeAgent({
       authorizedDID: did3,

--- a/packages/data-store/src/__tests__/data-store-orm.test.ts
+++ b/packages/data-store/src/__tests__/data-store-orm.test.ts
@@ -261,10 +261,10 @@ describe('@veramo/data-store queries', () => {
 
   test('works with relations', async () => {
     const credentials = await makeAgent().dataStoreORMGetVerifiableCredentialsByClaims({})
-    expect(credentials.length).toBe(3)
+    expect(credentials.length).toBe(1)
     expect(credentials[0].verifiableCredential.id).toBe('vc1')
     const count = await makeAgent().dataStoreORMGetVerifiableCredentialsByClaimsCount({})
-    expect(count).toBe(3)
+    expect(count).toBe(1)
 
     const credentials2 = await makeAgent({
       authorizedDID: did3,

--- a/packages/data-store/src/data-store-orm.ts
+++ b/packages/data-store/src/data-store-orm.ts
@@ -202,10 +202,17 @@ export class DataStoreORM implements IAgentPlugin {
     context: AuthorizedDIDContext,
   ): Promise<Array<UniqueVerifiableCredential>> {
     const claims = await (await this.claimsQuery(args, context)).getMany()
-    return claims.map((claim) => ({
-      hash: claim.credential.hash,
-      verifiableCredential: claim.credential.raw,
-    }))
+    return claims
+      .map((claim) => ({
+        hash: claim.credential.hash,
+        verifiableCredential: claim.credential.raw,
+      }))
+      .reduce((acc: UniqueVerifiableCredential[], current: UniqueVerifiableCredential) => {
+        if (!acc.some((item) => item.hash === current.hash)) {
+          acc.push(current)
+        }
+        return acc
+      }, [])
   }
 
   async dataStoreORMGetVerifiableCredentialsByClaimsCount(


### PR DESCRIPTION
Signed-off-by: Mirko Mollik <mirko.mollik@fit.fraunhofer.de>

## What issue is this PR fixing
fixes #1285

## What is being changed
It will reduce the credentials in case there were multiuple claims pointing to the claim credential

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because there was no existing test for this function and I am aware that a PR without tests will likely get rejected.
