### PR TITLE
fix(deps): add 'ethers@^6.7.1' dependency

### DIFF
--- a/packages/did-provider-ethr/package.json
+++ b/packages/did-provider-ethr/package.json
@@ -13,6 +13,7 @@
     "@veramo/core-types": "workspace:^",
     "@veramo/did-manager": "workspace:^",
     "debug": "^4.3.3",
+    "ethers": "^6.7.1",
     "ethr-did": "^3.0.1"
   },
   "devDependencies": {

--- a/packages/did-provider-ion/package.json
+++ b/packages/did-provider-ion/package.json
@@ -25,6 +25,7 @@
     "cross-fetch": "^4.0.0",
     "debug": "^4.3.3",
     "did-resolver": "^4.1.0",
+    "ethers": "^6.7.1",
     "multihashes": "^4.0.3"
   },
   "devDependencies": {

--- a/packages/did-provider-key/package.json
+++ b/packages/did-provider-key/package.json
@@ -17,7 +17,8 @@
     "@veramo/did-manager": "workspace:^",
     "@veramo/utils": "workspace:^",
     "debug": "^4.3.3",
-    "did-resolver": "^4.1.0"
+    "did-resolver": "^4.1.0",
+    "ethers": "^6.7.1"
   },
   "devDependencies": {
     "@types/debug": "4.1.8",

--- a/packages/did-provider-pkh/package.json
+++ b/packages/did-provider-pkh/package.json
@@ -14,7 +14,8 @@
     "@veramo/did-manager": "workspace:^",
     "caip": "^1.1.0",
     "debug": "^4.3.3",
-    "did-resolver": "^4.1.0"
+    "did-resolver": "^4.1.0",
+    "ethers": "^6.7.1"
   },
   "devDependencies": {
     "@types/debug": "4.1.8",

--- a/packages/key-manager/package.json
+++ b/packages/key-manager/package.json
@@ -15,6 +15,7 @@
     "@veramo/utils": "workspace:^",
     "debug": "^4.3.4",
     "did-jwt": "^7.4.1",
+    "ethers": "^6.7.1",
     "uint8arrays": "^4.0.6",
     "uuid": "^9.0.0"
   },

--- a/packages/kms-local/package.json
+++ b/packages/kms-local/package.json
@@ -17,7 +17,8 @@
     "@veramo/key-manager": "workspace:^",
     "@veramo/utils": "workspace:^",
     "debug": "^4.3.3",
-    "did-jwt": "^7.4.1"
+    "did-jwt": "^7.4.1",
+    "ethers": "^6.7.1"
   },
   "devDependencies": {
     "@types/debug": "4.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -776,6 +776,9 @@ importers:
       debug:
         specifier: ^4.3.3
         version: 4.3.4
+      ethers:
+        specifier: ^6.7.1
+        version: 6.7.1
       ethr-did:
         specifier: ^3.0.1
         version: 3.0.1
@@ -837,6 +840,9 @@ importers:
       did-resolver:
         specifier: ^4.1.0
         version: 4.1.0
+      ethers:
+        specifier: ^6.7.1
+        version: 6.7.1
       multihashes:
         specifier: ^4.0.3
         version: 4.0.3
@@ -911,6 +917,9 @@ importers:
       did-resolver:
         specifier: ^4.1.0
         version: 4.1.0
+      ethers:
+        specifier: ^6.7.1
+        version: 6.7.1
     devDependencies:
       '@types/debug':
         specifier: 4.1.8
@@ -964,6 +973,9 @@ importers:
       did-resolver:
         specifier: ^4.1.0
         version: 4.1.0
+      ethers:
+        specifier: ^6.7.1
+        version: 6.7.1
     devDependencies:
       '@types/debug':
         specifier: 4.1.8
@@ -1039,6 +1051,9 @@ importers:
       did-jwt:
         specifier: ^7.4.1
         version: 7.4.1
+      ethers:
+        specifier: ^6.7.1
+        version: 6.7.1
       uint8arrays:
         specifier: ^4.0.6
         version: 4.0.6
@@ -1082,6 +1097,9 @@ importers:
       did-jwt:
         specifier: ^7.4.1
         version: 7.4.1
+      ethers:
+        specifier: ^6.7.1
+        version: 6.7.1
     devDependencies:
       '@types/debug':
         specifier: 4.1.8


### PR DESCRIPTION
closes #1295

## What is being changed
Fix missing `ethers` dependency that utilized in each relevant modules.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [ ] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.

## Details
If applicable, add screen captures, error messages or stack traces to help explain your problem.
