### PR TITLE
fix(selective-disclosure): deprecate the uPort SelectiveDisclosure plugin

### DIFF
--- a/packages/selective-disclosure/src/action-handler.ts
+++ b/packages/selective-disclosure/src/action-handler.ts
@@ -38,7 +38,7 @@ import {
 
 /**
  * This class adds support for creating
- * {@link https://github.com/uport-project/specs/blob/develop/flows/selectivedisclosure.md | Selective Disclosure}
+ * {@link https://github.com/uport-project/specs/blob/develop/flows/selectivedisclosure.md | uPort Selective Disclosure}
  * requests and interpret the responses received.
  *
  * This implementation of the uPort protocol uses
@@ -46,6 +46,9 @@ import {
  * as the response encoding instead of a `shareReq`.
  *
  * @beta This API may change without a BREAKING CHANGE notice.
+ *
+ * @deprecated This plugin is deprecated as it implements a non-standard protocol created for the uPort project. It
+ *   will be removed in a future release.
  */
 export class SelectiveDisclosure implements IAgentPlugin {
   readonly methods: ISelectiveDisclosure
@@ -64,7 +67,7 @@ export class SelectiveDisclosure implements IAgentPlugin {
    * Creates a Selective disclosure request, encoded as a JWT.
    *
    * @remarks See
-   *   {@link https://github.com/uport-project/specs/blob/develop/flows/selectivedisclosure.md | Selective Disclosure}
+   *   {@link https://github.com/uport-project/specs/blob/develop/flows/selectivedisclosure.md | uPort Selective Disclosure}
    *
    * @param args - The param object with the properties necessary to create the request. See
    *   {@link ISelectiveDisclosureRequest}
@@ -187,7 +190,7 @@ export class SelectiveDisclosure implements IAgentPlugin {
 
   /**
    * Validates a
-   * {@link https://github.com/uport-project/specs/blob/develop/flows/selectivedisclosure.md | Selective Disclosure response} encoded as a `Presentation`
+   * {@link https://github.com/uport-project/specs/blob/develop/flows/selectivedisclosure.md | uPort Selective Disclosure response} encoded as a `Presentation`
    *
    * @param args - Contains the request and the response `Presentation` that needs to be checked.
    * @param context - *RESERVED* This is filled by the framework when the method is called.

--- a/packages/selective-disclosure/src/message-handler.ts
+++ b/packages/selective-disclosure/src/message-handler.ts
@@ -4,12 +4,14 @@ import { v4 as uuidv4 } from 'uuid'
 
 import Debug from 'debug'
 import { asArray, computeEntryHash } from '@veramo/utils'
+
 const debug = Debug('veramo:selective-disclosure:message-handler')
 
 /**
  * Identifies a {@link @veramo/core-types#IMessage} that represents a Selective Disclosure Request
  *
- * @remarks See {@link https://github.com/uport-project/specs/blob/develop/messages/sharereq.md | Selective Disclosure Request}
+ * @remarks See
+ *   {@link https://github.com/uport-project/specs/blob/develop/messages/sharereq.md | uPort Selective Disclosure Request}
  * @beta This API may change without a BREAKING CHANGE notice.
  */
 export const MessageTypes = {
@@ -21,6 +23,9 @@ export const MessageTypes = {
  * into the internal Message representation.
  *
  * @beta This API may change without a BREAKING CHANGE notice.
+ *
+ * @deprecated This plugin is deprecated as it implements a non-standard protocol created for the uPort project. It
+ *   will be removed in a future release.
  */
 export class SdrMessageHandler extends AbstractMessageHandler {
   async handle(message: Message, context: IAgentContext<IMessageHandler>): Promise<Message> {


### PR DESCRIPTION
## What issue is this PR fixing

Based on the discussion in https://github.com/decentralized-identity/veramo/issues/1276#issuecomment-1857576346 , the uPort-era-selective-disclosure-plugin should be marked as deprecated to be removed in a future release.