### PR TITLE
[proposal] make path output from generate schema dynamic

### DIFF
--- a/packages/cli/src/dev.ts
+++ b/packages/cli/src/dev.ts
@@ -95,9 +95,11 @@ dev
     'package.json file containing a Veramo plugin interface config',
     './package.json',
   )
+  .option('-o, --output <string>', 'Output file of the schema', './src/plugin.schema.json')
 
   .action(async (options) => {
     const apiExtractorJsonPath: string = resolve(options.extractorConfig)
+    const outPutPath: string = resolve(options.output)
     const extractorConfig: ExtractorConfig = ExtractorConfig.loadFileAndPrepare(apiExtractorJsonPath)
 
     const extractorResult: ExtractorResult = Extractor.invoke(extractorConfig, {
@@ -184,7 +186,7 @@ dev
       interfaces[pluginInterfaceName] = api
     }
 
-    writeFileSync(resolve('./src/plugin.schema.json'), JSON.stringify(interfaces, null, 2))
+    writeFileSync(resolve(outPutPath), JSON.stringify(interfaces, null, 2))
   })
 
 dev


### PR DESCRIPTION
## What issue is this PR fixing

Example:
fixes #1317


## What is being changed
Adding a new parameter to the cli so the path and file of the `plugin.schema.json`.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.
