### PR TITLE
fix(credential-ld): let verifiers use all supported verification methods

### DIFF
--- a/__tests__/shared/verifiableDataLD.ts
+++ b/__tests__/shared/verifiableDataLD.ts
@@ -230,7 +230,8 @@ export default (testContext: {
 
       // Check credential:
       expect(verifiableCredential).toHaveProperty('proof')
-      expect(verifiableCredential).toHaveProperty('proof.jws')
+      const proofValue = verifiableCredential.proof.jws ?? verifiableCredential.proof.proofValue
+      expect(proofValue).toBeDefined()
       expect(verifiableCredential.proof.verificationMethod).toEqual(
         `${didKeyIdentifier.did}#${didKeyIdentifier.did.substring(
           didKeyIdentifier.did.lastIndexOf(':') + 1,

--- a/packages/credential-ld/src/ld-suite-loader.ts
+++ b/packages/credential-ld/src/ld-suite-loader.ts
@@ -1,23 +1,23 @@
 import { VeramoLdSignature } from './ld-suites.js'
 import { TKeyType } from '@veramo/core-types'
+import { asArray } from '@veramo/utils'
 
 /**
  * Initializes a list of Veramo-wrapped LD Signature suites and exposes those to the Agent Module
  */
 export class LdSuiteLoader {
   constructor(options: { veramoLdSignatures: VeramoLdSignature[] }) {
-    options.veramoLdSignatures.forEach((obj) => {
-      // FIXME: some suites would work for multiple key types, but this only returns a single value per suite.
-      //       For example, EcdsaSecp256k1RecoverySignature2020 should work with both EcdsaSecp256k1VerificationKey2019
-      //       as well as EcdsaSecp256k1RecoveryMethod2020 since the VerificationKey can also be expressed as the recovery
-      //       method.
-      const keyType = obj.getSupportedVeramoKeyType()
-      const verificationType = obj.getSupportedVerificationType()
-      return (this.signatureMap[keyType] = { ...this.signatureMap[keyType], [verificationType]: obj })
+    options.veramoLdSignatures.forEach((ldSuite) => {
+      const keyType = ldSuite.getSupportedVeramoKeyType()
+      let verifierMapping = this.signatureMap[keyType] ?? {}
+      asArray(ldSuite.getSupportedVerificationType()).forEach((verificationType) => {
+        verifierMapping[verificationType] = [...(verifierMapping[verificationType] ?? []), ldSuite]
+      })
+      return (this.signatureMap[keyType] = { ...this.signatureMap[keyType], ...verifierMapping })
     })
   }
 
-  private signatureMap: Record<string, Record<string, VeramoLdSignature>> = {}
+  private signatureMap: Record<string, Record<string, VeramoLdSignature[]>> = {}
 
   getSignatureSuiteForKeyType(type: TKeyType, verificationType: string) {
     const suite = this.signatureMap[type]?.[verificationType]
@@ -29,7 +29,7 @@ export class LdSuiteLoader {
   getAllSignatureSuites(): VeramoLdSignature[] {
     return Object.values(this.signatureMap)
       .map((x) => Object.values(x))
-      .flat()
+      .flat(2)
   }
 
   getAllSignatureSuiteTypes() {

--- a/packages/credential-ld/src/ld-suites.ts
+++ b/packages/credential-ld/src/ld-suites.ts
@@ -23,7 +23,7 @@ export abstract class VeramoLdSignature {
   // Add type definition as soon as https://github.com/digitalbazaar/jsonld-signatures
   // supports those.
 
-  abstract getSupportedVerificationType(): string
+  abstract getSupportedVerificationType(): string | string[]
 
   abstract getSupportedVeramoKeyType(): TKeyType
 

--- a/packages/credential-ld/src/suites/EcdsaSecp256k1RecoverySignature2020.ts
+++ b/packages/credential-ld/src/suites/EcdsaSecp256k1RecoverySignature2020.ts
@@ -13,6 +13,8 @@ const { EcdsaSecp256k1RecoveryMethod2020, EcdsaSecp256k1RecoverySignature2020 } 
 export class VeramoEcdsaSecp256k1RecoverySignature2020 extends VeramoLdSignature {
   getSupportedVerificationType(): string {
     return 'EcdsaSecp256k1RecoveryMethod2020'
+    // TODO: add support for ['EcdsaSecp256k1VerificationKey2020', 'EcdsaSecp256k1VerificationKey2019',
+    // 'JsonWebKey2020', 'Multikey']
   }
 
   getSupportedVeramoKeyType(): TKeyType {
@@ -52,7 +54,7 @@ export class VeramoEcdsaSecp256k1RecoverySignature2020 extends VeramoLdSignature
       key: new EcdsaSecp256k1RecoveryMethod2020({
         publicKeyHex: key.publicKeyHex,
         signer: () => signer,
-        type: this.getSupportedVerificationType(),
+        type: 'EcdsaSecp256k1RecoveryMethod2020',
         controller,
         id: verifiableMethodId,
       }),

--- a/packages/credential-ld/src/suites/Ed25519Signature2018.ts
+++ b/packages/credential-ld/src/suites/Ed25519Signature2018.ts
@@ -9,8 +9,9 @@ import { Ed25519Signature2018, Ed25519VerificationKey2018 } from '@transmute/ed2
  * @alpha This API is experimental and is very likely to change or disappear in future releases without notice.
  */
 export class VeramoEd25519Signature2018 extends VeramoLdSignature {
-  getSupportedVerificationType(): string {
-    return 'Ed25519VerificationKey2018'
+  getSupportedVerificationType(): string[] {
+    return ['Ed25519VerificationKey2018', 'JsonWebKey2020']
+    // TODO: add support for ['Ed25519VerificationKey2020', 'Multikey']
   }
 
   getSupportedVeramoKeyType(): TKeyType {
@@ -54,7 +55,7 @@ export class VeramoEd25519Signature2018 extends VeramoLdSignature {
       controller,
       publicKey: hexToBytes(key.publicKeyHex),
       signer: () => signer,
-      type: this.getSupportedVerificationType(),
+      type: 'Ed25519VerificationKey2018',
     })
     // overwrite the signer since we're not passing the private key and transmute doesn't support that behavior
     verificationKey.signer = () => signer as any

--- a/packages/credential-ld/src/suites/Ed25519Signature2020.ts
+++ b/packages/credential-ld/src/suites/Ed25519Signature2020.ts
@@ -30,8 +30,9 @@ const debug = Debug('veramo:credential-ld:Ed25519Signature2020')
  * @alpha This API is experimental and is very likely to change or disappear in future releases without notice.
  */
 export class VeramoEd25519Signature2020 extends VeramoLdSignature {
-  getSupportedVerificationType(): string {
-    return 'Ed25519VerificationKey2020'
+  getSupportedVerificationType(): string[] {
+    return ['Ed25519VerificationKey2020', 'Ed25519VerificationKey2018']
+    // TODO: add support for ['JsonWebKey2020', 'Multikey']
   }
 
   getSupportedVeramoKeyType(): TKeyType {
@@ -72,7 +73,7 @@ export class VeramoEd25519Signature2020 extends VeramoLdSignature {
     })
     // overwrite the signer since we're not passing the private key
     verificationKey.signer = () => signer as any
-    verificationKey.type = this.getSupportedVerificationType()
+    verificationKey.type = 'Ed25519VerificationKey2020'
     return new Ed25519Signature2020({
       key: verificationKey,
       signer: signer,

--- a/packages/credential-ld/src/suites/JsonWebSignature2020.ts
+++ b/packages/credential-ld/src/suites/JsonWebSignature2020.ts
@@ -17,8 +17,9 @@ import {
  * @alpha This API is experimental and is very likely to change or disappear in future releases without notice.
  */
 export class VeramoJsonWebSignature2020 extends VeramoLdSignature {
-  getSupportedVerificationType(): 'JsonWebKey2020' {
+  getSupportedVerificationType(): string {
     return 'JsonWebKey2020'
+      // TODO: add support for ['Ed25519VerificationKey2018', 'Ed25519VerificationKey2020', 'Multikey'] and others
   }
 
   getSupportedVeramoKeyType(): TKeyType {
@@ -59,7 +60,7 @@ export class VeramoJsonWebSignature2020 extends VeramoLdSignature {
 
     const verificationKey = await JsonWebKey.from({
       id: id,
-      type: this.getSupportedVerificationType(),
+      type: 'JsonWebKey2020',
       controller: controller,
       publicKeyJwk: {
         kty: 'OKP',


### PR DESCRIPTION
## What issue is this PR fixing

fixes #1329

## What is being changed

The `VeramoLdSignature.getSupportedVerificationType()` can now return `string[]` as well as `string`
This allows `VeramoLdSignature` suite implementations to signal compatibility with multiple Verification Method types for verification.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.