### PR TITLE
fix(did-provider-key): align did:key resolver to spec

### DIFF
--- a/__tests__/shared/verifiableDataLD.ts
+++ b/__tests__/shared/verifiableDataLD.ts
@@ -230,7 +230,8 @@ export default (testContext: {
 
       // Check credential:
       expect(verifiableCredential).toHaveProperty('proof')
-      expect(verifiableCredential).toHaveProperty('proof.jws')
+      const proofValue = verifiableCredential.proof.jws ?? verifiableCredential.proof.proofValue
+      expect(proofValue).toBeDefined()
       expect(verifiableCredential.proof.verificationMethod).toEqual(
         `${didKeyIdentifier.did}#${didKeyIdentifier.did.substring(
           didKeyIdentifier.did.lastIndexOf(':') + 1,

--- a/packages/credential-eip712/src/agent/CredentialEIP712.ts
+++ b/packages/credential-eip712/src/agent/CredentialEIP712.ts
@@ -29,7 +29,7 @@ import {
   IRequiredContext,
   IVerifyCredentialEIP712Args,
   IVerifyPresentationEIP712Args,
-} from '../types/ICredentialEIP712'
+} from '../types/ICredentialEIP712.js'
 
 import { getEthTypesFromInputDoc } from 'eip-712-types-generation'
 

--- a/packages/credential-ld/src/ld-suite-loader.ts
+++ b/packages/credential-ld/src/ld-suite-loader.ts
@@ -1,23 +1,23 @@
 import { VeramoLdSignature } from './ld-suites.js'
 import { TKeyType } from '@veramo/core-types'
+import { asArray } from '@veramo/utils'
 
 /**
  * Initializes a list of Veramo-wrapped LD Signature suites and exposes those to the Agent Module
  */
 export class LdSuiteLoader {
   constructor(options: { veramoLdSignatures: VeramoLdSignature[] }) {
-    options.veramoLdSignatures.forEach((obj) => {
-      // FIXME: some suites would work for multiple key types, but this only returns a single value per suite.
-      //       For example, EcdsaSecp256k1RecoverySignature2020 should work with both EcdsaSecp256k1VerificationKey2019
-      //       as well as EcdsaSecp256k1RecoveryMethod2020 since the VerificationKey can also be expressed as the recovery
-      //       method.
-      const keyType = obj.getSupportedVeramoKeyType()
-      const verificationType = obj.getSupportedVerificationType()
-      return (this.signatureMap[keyType] = { ...this.signatureMap[keyType], [verificationType]: obj })
+    options.veramoLdSignatures.forEach((ldSuite) => {
+      const keyType = ldSuite.getSupportedVeramoKeyType()
+      let verifierMapping = this.signatureMap[keyType] ?? {}
+      asArray(ldSuite.getSupportedVerificationType()).forEach((verificationType) => {
+        verifierMapping[verificationType] = [...(verifierMapping[verificationType] ?? []), ldSuite]
+      })
+      return (this.signatureMap[keyType] = { ...this.signatureMap[keyType], ...verifierMapping })
     })
   }
 
-  private signatureMap: Record<string, Record<string, VeramoLdSignature>> = {}
+  private signatureMap: Record<string, Record<string, VeramoLdSignature[]>> = {}
 
   getSignatureSuiteForKeyType(type: TKeyType, verificationType: string) {
     const suite = this.signatureMap[type]?.[verificationType]
@@ -29,7 +29,7 @@ export class LdSuiteLoader {
   getAllSignatureSuites(): VeramoLdSignature[] {
     return Object.values(this.signatureMap)
       .map((x) => Object.values(x))
-      .flat()
+      .flat(2)
   }
 
   getAllSignatureSuiteTypes() {

--- a/packages/credential-ld/src/ld-suites.ts
+++ b/packages/credential-ld/src/ld-suites.ts
@@ -23,7 +23,7 @@ export abstract class VeramoLdSignature {
   // Add type definition as soon as https://github.com/digitalbazaar/jsonld-signatures
   // supports those.
 
-  abstract getSupportedVerificationType(): string
+  abstract getSupportedVerificationType(): string | string[]
 
   abstract getSupportedVeramoKeyType(): TKeyType
 

--- a/packages/credential-ld/src/suites/EcdsaSecp256k1RecoverySignature2020.ts
+++ b/packages/credential-ld/src/suites/EcdsaSecp256k1RecoverySignature2020.ts
@@ -13,6 +13,8 @@ const { EcdsaSecp256k1RecoveryMethod2020, EcdsaSecp256k1RecoverySignature2020 } 
 export class VeramoEcdsaSecp256k1RecoverySignature2020 extends VeramoLdSignature {
   getSupportedVerificationType(): string {
     return 'EcdsaSecp256k1RecoveryMethod2020'
+    // TODO: add support for ['EcdsaSecp256k1VerificationKey2020', 'EcdsaSecp256k1VerificationKey2019',
+    // 'JsonWebKey2020', 'Multikey']
   }
 
   getSupportedVeramoKeyType(): TKeyType {
@@ -52,7 +54,7 @@ export class VeramoEcdsaSecp256k1RecoverySignature2020 extends VeramoLdSignature
       key: new EcdsaSecp256k1RecoveryMethod2020({
         publicKeyHex: key.publicKeyHex,
         signer: () => signer,
-        type: this.getSupportedVerificationType(),
+        type: 'EcdsaSecp256k1RecoveryMethod2020',
         controller,
         id: verifiableMethodId,
       }),

--- a/packages/credential-ld/src/suites/Ed25519Signature2018.ts
+++ b/packages/credential-ld/src/suites/Ed25519Signature2018.ts
@@ -9,8 +9,9 @@ import { Ed25519Signature2018, Ed25519VerificationKey2018 } from '@transmute/ed2
  * @alpha This API is experimental and is very likely to change or disappear in future releases without notice.
  */
 export class VeramoEd25519Signature2018 extends VeramoLdSignature {
-  getSupportedVerificationType(): string {
-    return 'Ed25519VerificationKey2018'
+  getSupportedVerificationType(): string[] {
+    return ['Ed25519VerificationKey2018', 'JsonWebKey2020']
+    // TODO: add support for ['Ed25519VerificationKey2020', 'Multikey']
   }
 
   getSupportedVeramoKeyType(): TKeyType {
@@ -54,7 +55,7 @@ export class VeramoEd25519Signature2018 extends VeramoLdSignature {
       controller,
       publicKey: hexToBytes(key.publicKeyHex),
       signer: () => signer,
-      type: this.getSupportedVerificationType(),
+      type: 'Ed25519VerificationKey2018',
     })
     // overwrite the signer since we're not passing the private key and transmute doesn't support that behavior
     verificationKey.signer = () => signer as any

--- a/packages/credential-ld/src/suites/Ed25519Signature2020.ts
+++ b/packages/credential-ld/src/suites/Ed25519Signature2020.ts
@@ -30,8 +30,9 @@ const debug = Debug('veramo:credential-ld:Ed25519Signature2020')
  * @alpha This API is experimental and is very likely to change or disappear in future releases without notice.
  */
 export class VeramoEd25519Signature2020 extends VeramoLdSignature {
-  getSupportedVerificationType(): string {
-    return 'Ed25519VerificationKey2020'
+  getSupportedVerificationType(): string[] {
+    return ['Ed25519VerificationKey2020', 'Ed25519VerificationKey2018']
+    // TODO: add support for ['JsonWebKey2020', 'Multikey']
   }
 
   getSupportedVeramoKeyType(): TKeyType {
@@ -72,7 +73,7 @@ export class VeramoEd25519Signature2020 extends VeramoLdSignature {
     })
     // overwrite the signer since we're not passing the private key
     verificationKey.signer = () => signer as any
-    verificationKey.type = this.getSupportedVerificationType()
+    verificationKey.type = 'Ed25519VerificationKey2020'
     return new Ed25519Signature2020({
       key: verificationKey,
       signer: signer,

--- a/packages/credential-ld/src/suites/JsonWebSignature2020.ts
+++ b/packages/credential-ld/src/suites/JsonWebSignature2020.ts
@@ -17,8 +17,9 @@ import {
  * @alpha This API is experimental and is very likely to change or disappear in future releases without notice.
  */
 export class VeramoJsonWebSignature2020 extends VeramoLdSignature {
-  getSupportedVerificationType(): 'JsonWebKey2020' {
+  getSupportedVerificationType(): string {
     return 'JsonWebKey2020'
+      // TODO: add support for ['Ed25519VerificationKey2018', 'Ed25519VerificationKey2020', 'Multikey'] and others
   }
 
   getSupportedVeramoKeyType(): TKeyType {
@@ -59,7 +60,7 @@ export class VeramoJsonWebSignature2020 extends VeramoLdSignature {
 
     const verificationKey = await JsonWebKey.from({
       id: id,
-      type: this.getSupportedVerificationType(),
+      type: 'JsonWebKey2020',
       controller: controller,
       publicKeyJwk: {
         kty: 'OKP',

--- a/packages/credential-status/package.json
+++ b/packages/credential-status/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@veramo/core-types": "workspace:^",
     "@veramo/utils": "workspace:^",
-    "credential-status": "^2.0.5",
+    "credential-status": "^3.0.0",
     "did-jwt": "^8.0.0",
     "did-resolver": "^4.1.0"
   },

--- a/packages/did-discovery/src/action-handler.ts
+++ b/packages/did-discovery/src/action-handler.ts
@@ -5,7 +5,7 @@ import {
   IDIDDiscoveryDiscoverDidArgs,
   IDIDDiscoveryProviderResult,
   IDIDDiscoveryDiscoverDidResult,
-} from './types'
+} from './types.js'
 import { AbstractDidDiscoveryProvider } from './abstract-did-discovery-provider.js'
 import { schema } from './plugin.schema.js'
 import Debug from 'debug'

--- a/packages/did-provider-key/package.json
+++ b/packages/did-provider-key/package.json
@@ -10,9 +10,6 @@
     "extract-api": "node ../cli/bin/veramo.js dev extract-api"
   },
   "dependencies": {
-    "@transmute/did-key-ed25519": "^0.3.0-unstable.10",
-    "@transmute/did-key-secp256k1": "^0.3.0-unstable.10",
-    "@transmute/did-key-x25519": "^0.3.0-unstable.10",
     "@veramo/core-types": "workspace:^",
     "@veramo/did-manager": "workspace:^",
     "@veramo/utils": "workspace:^",

--- a/packages/did-provider-key/src/__tests__/key.resolver.test.ts
+++ b/packages/did-provider-key/src/__tests__/key.resolver.test.ts
@@ -1,0 +1,526 @@
+import { Resolver } from 'did-resolver'
+import { getDidKeyResolver } from '../resolver.js'
+
+const resolver = new Resolver(getDidKeyResolver())
+
+describe('did:key resolver', () => {
+  describe('Ed25519', () => {
+    it('should resolve with defaults', async () => {
+      const sigMultibase = 'z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK'
+      const encMultibase = 'z6LSj72tK8brWgZja8NLRwPigth2T9QRiG1uH9oKZuKjdh9p'
+      const did = `did:key:${sigMultibase}`
+      const result = await resolver.resolve(did)
+
+      const expectedResult = {
+        didDocumentMetadata: { contentType: 'application/did+ld+json' },
+        didResolutionMetadata: {},
+        didDocument: {
+          id: did,
+          verificationMethod: [
+            {
+              id: `${did}#${sigMultibase}`,
+              type: 'JsonWebKey2020',
+              controller: did,
+              publicKeyJwk: {
+                alg: 'EdDSA',
+                crv: 'Ed25519',
+                kty: 'OKP',
+                use: 'sig',
+                x: 'Lm_M42cB3HkUiODQsXRcweM6TByfzEHGO9ND274JcOY',
+              },
+            },
+            {
+              id: `${did}#${encMultibase}`,
+              type: 'JsonWebKey2020',
+              controller: did,
+              publicKeyJwk: {
+                alg: 'ECDH-ES',
+                crv: 'X25519',
+                kty: 'OKP',
+                use: 'enc',
+                x: 'bl_3kgKpz9jgsg350CNuHa_kQL3B60Gi-98WmdQW2h8',
+              },
+            },
+          ],
+          authentication: [`${did}#${sigMultibase}`],
+          assertionMethod: [`${did}#${sigMultibase}`],
+          capabilityDelegation: [`${did}#${sigMultibase}`],
+          capabilityInvocation: [`${did}#${sigMultibase}`],
+          keyAgreement: [`${did}#${encMultibase}`],
+          '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/suites/jws-2020/v1'],
+        },
+      }
+
+      expect(result).toEqual(expectedResult)
+    })
+
+    it('should resolve with Multikey', async () => {
+      const sigMultibase = 'z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK'
+      const encMultibase = 'z6LSj72tK8brWgZja8NLRwPigth2T9QRiG1uH9oKZuKjdh9p'
+      const did = `did:key:${sigMultibase}`
+      const result = await resolver.resolve(did, { publicKeyFormat: 'Multikey' })
+
+      const expectedResult = {
+        didDocumentMetadata: { contentType: 'application/did+ld+json' },
+        didResolutionMetadata: {},
+        didDocument: {
+          id: did,
+          verificationMethod: [
+            {
+              id: `${did}#${sigMultibase}`,
+              type: 'Multikey',
+              controller: did,
+              publicKeyMultibase: sigMultibase,
+            },
+            {
+              id: `${did}#${encMultibase}`,
+              type: 'Multikey',
+              controller: did,
+              publicKeyMultibase: encMultibase,
+            },
+          ],
+          authentication: [`${did}#${sigMultibase}`],
+          assertionMethod: [`${did}#${sigMultibase}`],
+          capabilityDelegation: [`${did}#${sigMultibase}`],
+          capabilityInvocation: [`${did}#${sigMultibase}`],
+          keyAgreement: [`${did}#${encMultibase}`],
+          '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/multikey/v1'],
+        },
+      }
+
+      expect(result).toEqual(expectedResult)
+    })
+
+    it('should resolve with 2020 suite', async () => {
+      const sigMultibase = 'z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK'
+      const encMultibase = 'z6LSj72tK8brWgZja8NLRwPigth2T9QRiG1uH9oKZuKjdh9p'
+      const did = `did:key:${sigMultibase}`
+      const result = await resolver.resolve(did, { publicKeyFormat: 'Ed25519VerificationKey2020' })
+
+      const expectedResult = {
+        didDocumentMetadata: { contentType: 'application/did+ld+json' },
+        didResolutionMetadata: {},
+        didDocument: {
+          id: did,
+          verificationMethod: [
+            {
+              id: `${did}#${sigMultibase}`,
+              type: 'Ed25519VerificationKey2020',
+              controller: did,
+              publicKeyMultibase: sigMultibase,
+            },
+            {
+              id: `${did}#${encMultibase}`,
+              type: 'X25519KeyAgreementKey2020',
+              controller: did,
+              publicKeyMultibase: encMultibase,
+            },
+          ],
+          authentication: [`${did}#${sigMultibase}`],
+          assertionMethod: [`${did}#${sigMultibase}`],
+          capabilityDelegation: [`${did}#${sigMultibase}`],
+          capabilityInvocation: [`${did}#${sigMultibase}`],
+          keyAgreement: [`${did}#${encMultibase}`],
+          '@context': [
+            'https://www.w3.org/ns/did/v1',
+            'https://w3id.org/security/suites/ed25519-2020/v1',
+            'https://w3id.org/security/suites/x25519-2020/v1',
+          ],
+        },
+      }
+
+      expect(result).toEqual(expectedResult)
+    })
+
+    it('should resolve with 2018 suite', async () => {
+      const sigMultibase = 'z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK'
+      const encMultibase = 'z6LSj72tK8brWgZja8NLRwPigth2T9QRiG1uH9oKZuKjdh9p'
+      const did = `did:key:${sigMultibase}`
+      const result = await resolver.resolve(did, { publicKeyFormat: 'Ed25519VerificationKey2018' })
+
+      const expectedResult = {
+        didDocumentMetadata: { contentType: 'application/did+ld+json' },
+        didResolutionMetadata: {},
+        didDocument: {
+          id: did,
+          verificationMethod: [
+            {
+              id: `${did}#${sigMultibase}`,
+              type: 'Ed25519VerificationKey2018',
+              controller: did,
+              publicKeyBase58: '48GdbJyVULjHDaBNS6ct9oAGtckZUS5v8asrPzvZ7R1w',
+            },
+            {
+              id: `${did}#${encMultibase}`,
+              type: 'X25519KeyAgreementKey2019',
+              controller: did,
+              publicKeyBase58: '8RrinpnzRDqzUjzZuHsmNJUYbzsK1eqkQB5e5SgCvKP4',
+            },
+          ],
+          authentication: [`${did}#${sigMultibase}`],
+          assertionMethod: [`${did}#${sigMultibase}`],
+          capabilityDelegation: [`${did}#${sigMultibase}`],
+          capabilityInvocation: [`${did}#${sigMultibase}`],
+          keyAgreement: [`${did}#${encMultibase}`],
+          '@context': [
+            'https://www.w3.org/ns/did/v1',
+            'https://w3id.org/security/suites/ed25519-2018/v1',
+            'https://w3id.org/security/suites/x25519-2019/v1',
+          ],
+        },
+      }
+
+      expect(result).toEqual(expectedResult)
+    })
+  })
+
+  describe('X25519', () => {
+    it('should resolve with defaults', async () => {
+      const encMultibase = 'z6LSj72tK8brWgZja8NLRwPigth2T9QRiG1uH9oKZuKjdh9p'
+      const did = `did:key:${encMultibase}`
+      const result = await resolver.resolve(did)
+
+      const expectedResult = {
+        didDocumentMetadata: { contentType: 'application/did+ld+json' },
+        didResolutionMetadata: {},
+        didDocument: {
+          id: did,
+          verificationMethod: [
+            {
+              id: `${did}#${encMultibase}`,
+              type: 'JsonWebKey2020',
+              controller: did,
+              publicKeyJwk: {
+                alg: 'ECDH-ES',
+                crv: 'X25519',
+                kty: 'OKP',
+                use: 'enc',
+                x: 'bl_3kgKpz9jgsg350CNuHa_kQL3B60Gi-98WmdQW2h8',
+              },
+            },
+          ],
+          keyAgreement: [`${did}#${encMultibase}`],
+          '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/suites/jws-2020/v1'],
+        },
+      }
+
+      expect(result).toEqual(expectedResult)
+    })
+
+    it('should resolve with Multikey', async () => {
+      const encMultibase = 'z6LSj72tK8brWgZja8NLRwPigth2T9QRiG1uH9oKZuKjdh9p'
+      const did = `did:key:${encMultibase}`
+      const result = await resolver.resolve(did, { publicKeyFormat: 'Multikey' })
+
+      const expectedResult = {
+        didDocumentMetadata: { contentType: 'application/did+ld+json' },
+        didResolutionMetadata: {},
+        didDocument: {
+          id: did,
+          verificationMethod: [
+            {
+              id: `${did}#${encMultibase}`,
+              type: 'Multikey',
+              controller: did,
+              publicKeyMultibase: encMultibase,
+            },
+          ],
+          keyAgreement: [`${did}#${encMultibase}`],
+          '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/multikey/v1'],
+        },
+      }
+
+      expect(result).toEqual(expectedResult)
+    })
+
+    it('should resolve with 2020 suite', async () => {
+      const encMultibase = 'z6LSj72tK8brWgZja8NLRwPigth2T9QRiG1uH9oKZuKjdh9p'
+      const did = `did:key:${encMultibase}`
+      const result = await resolver.resolve(did, { publicKeyFormat: 'X25519KeyAgreementKey2020' })
+
+      const expectedResult = {
+        didDocumentMetadata: { contentType: 'application/did+ld+json' },
+        didResolutionMetadata: {},
+        didDocument: {
+          id: did,
+          verificationMethod: [
+            {
+              id: `${did}#${encMultibase}`,
+              type: 'X25519KeyAgreementKey2020',
+              controller: did,
+              publicKeyMultibase: encMultibase,
+            },
+          ],
+          keyAgreement: [`${did}#${encMultibase}`],
+          '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/suites/x25519-2020/v1'],
+        },
+      }
+
+      expect(result).toEqual(expectedResult)
+    })
+
+    it('should resolve with 2019 suite', async () => {
+      const encMultibase = 'z6LSj72tK8brWgZja8NLRwPigth2T9QRiG1uH9oKZuKjdh9p'
+      const did = `did:key:${encMultibase}`
+      const result = await resolver.resolve(did, { publicKeyFormat: 'X25519KeyAgreementKey2019' })
+
+      const expectedResult = {
+        didDocumentMetadata: { contentType: 'application/did+ld+json' },
+        didResolutionMetadata: {},
+        didDocument: {
+          id: did,
+          verificationMethod: [
+            {
+              id: `${did}#${encMultibase}`,
+              type: 'X25519KeyAgreementKey2019',
+              controller: did,
+              publicKeyBase58: '8RrinpnzRDqzUjzZuHsmNJUYbzsK1eqkQB5e5SgCvKP4',
+            },
+          ],
+          keyAgreement: [`${did}#${encMultibase}`],
+          '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/suites/x25519-2019/v1'],
+        },
+      }
+
+      expect(result).toEqual(expectedResult)
+    })
+  })
+
+  describe('Secp256k1', () => {
+    it('should resolve with defaults', async () => {
+      const sigMultibase = 'zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme'
+      const did = `did:key:${sigMultibase}`
+      const result = await resolver.resolve(did)
+
+      const expectedResult = {
+        didDocumentMetadata: { contentType: 'application/did+ld+json' },
+        didResolutionMetadata: {},
+        didDocument: {
+          id: did,
+          verificationMethod: [
+            {
+              id: `${did}#${sigMultibase}`,
+              type: 'JsonWebKey2020',
+              controller: did,
+              publicKeyJwk: {
+                alg: 'ES256K',
+                crv: 'secp256k1',
+                kty: 'EC',
+                use: 'sig',
+                x: 'h0wVx_2iDlOcblulc8E5iEw1EYh5n1RYtLQfeSTyNc0',
+                y: 'O2EATIGbu6DezKFptj5scAIRntgfecanVNXxat1rnwE',
+              },
+            },
+          ],
+          authentication: [`${did}#${sigMultibase}`],
+          assertionMethod: [`${did}#${sigMultibase}`],
+          capabilityDelegation: [`${did}#${sigMultibase}`],
+          capabilityInvocation: [`${did}#${sigMultibase}`],
+          '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/suites/jws-2020/v1'],
+        },
+      }
+
+      expect(result).toEqual(expectedResult)
+    })
+
+    it('should resolve with Multikey', async () => {
+      const sigMultibase = 'zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme'
+      const did = `did:key:${sigMultibase}`
+      const result = await resolver.resolve(did, { publicKeyFormat: 'Multikey' })
+
+      const expectedResult = {
+        didDocumentMetadata: { contentType: 'application/did+ld+json' },
+        didResolutionMetadata: {},
+        didDocument: {
+          id: did,
+          verificationMethod: [
+            {
+              id: `${did}#${sigMultibase}`,
+              type: 'Multikey',
+              controller: did,
+              publicKeyMultibase: sigMultibase,
+            },
+          ],
+          authentication: [`${did}#${sigMultibase}`],
+          assertionMethod: [`${did}#${sigMultibase}`],
+          capabilityDelegation: [`${did}#${sigMultibase}`],
+          capabilityInvocation: [`${did}#${sigMultibase}`],
+          '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/multikey/v1'],
+        },
+      }
+
+      expect(result).toEqual(expectedResult)
+    })
+
+    it('should resolve with 2020 suite', async () => {
+      const sigMultibase = 'zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme'
+      const did = `did:key:${sigMultibase}`
+      const result = await resolver.resolve(did, { publicKeyFormat: 'EcdsaSecp256k1VerificationKey2020' })
+
+      const expectedResult = {
+        didDocumentMetadata: { contentType: 'application/did+ld+json' },
+        didResolutionMetadata: {},
+        didDocument: {
+          id: did,
+          verificationMethod: [
+            {
+              id: `${did}#${sigMultibase}`,
+              type: 'EcdsaSecp256k1VerificationKey2020',
+              controller: did,
+              publicKeyMultibase: sigMultibase,
+            },
+          ],
+          authentication: [`${did}#${sigMultibase}`],
+          assertionMethod: [`${did}#${sigMultibase}`],
+          capabilityDelegation: [`${did}#${sigMultibase}`],
+          capabilityInvocation: [`${did}#${sigMultibase}`],
+          '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/suites/secp256k1-2020/v1'],
+        },
+      }
+
+      expect(result).toEqual(expectedResult)
+    })
+
+    it('should resolve with 2019 suite', async () => {
+      const sigMultibase = 'zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme'
+      const did = `did:key:${sigMultibase}`
+      const result = await resolver.resolve(did, { publicKeyFormat: 'EcdsaSecp256k1VerificationKey2019' })
+
+      const expectedResult = {
+        didDocumentMetadata: { contentType: 'application/did+ld+json' },
+        didResolutionMetadata: {},
+        didDocument: {
+          id: did,
+          verificationMethod: [
+            {
+              id: `${did}#${sigMultibase}`,
+              type: 'EcdsaSecp256k1VerificationKey2019',
+              controller: did,
+              publicKeyMultibase: sigMultibase,
+            },
+          ],
+          authentication: [`${did}#${sigMultibase}`],
+          assertionMethod: [`${did}#${sigMultibase}`],
+          capabilityDelegation: [`${did}#${sigMultibase}`],
+          capabilityInvocation: [`${did}#${sigMultibase}`],
+          '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/suites/secp256k1-2019/v1'],
+        },
+      }
+
+      expect(result).toEqual(expectedResult)
+    })
+  })
+
+  describe('P-256', () => {
+    it('should resolve with defaults', async () => {
+      const sigMultibase = 'zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169'
+      const did = `did:key:${sigMultibase}`
+      const result = await resolver.resolve(did)
+
+      const expectedResult = {
+        didDocumentMetadata: { contentType: 'application/did+ld+json' },
+        didResolutionMetadata: {},
+        didDocument: {
+          id: did,
+          verificationMethod: [
+            {
+              id: `${did}#${sigMultibase}`,
+              type: 'JsonWebKey2020',
+              controller: did,
+              publicKeyJwk: {
+                alg: 'ES256',
+                crv: 'P-256',
+                kty: 'EC',
+                use: 'sig',
+                x: 'fyNYMN0976ci7xqiSdag3buk-ZCwgXU4kz9XNkBlNUI',
+                y: 'hW2ojTNfH7Jbi8--CJUo3OCbH3y5n91g-IMA9MLMbTU',
+              },
+            },
+          ],
+          authentication: [`${did}#${sigMultibase}`],
+          assertionMethod: [`${did}#${sigMultibase}`],
+          capabilityDelegation: [`${did}#${sigMultibase}`],
+          capabilityInvocation: [`${did}#${sigMultibase}`],
+          '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/suites/jws-2020/v1'],
+        },
+      }
+
+      expect(result).toEqual(expectedResult)
+    })
+
+    it('should resolve with Multikey', async () => {
+      const sigMultibase = 'zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169'
+      const did = `did:key:${sigMultibase}`
+      const result = await resolver.resolve(did, { publicKeyFormat: 'Multikey' })
+
+      const expectedResult = {
+        didDocumentMetadata: { contentType: 'application/did+ld+json' },
+        didResolutionMetadata: {},
+        didDocument: {
+          id: did,
+          verificationMethod: [
+            {
+              id: `${did}#${sigMultibase}`,
+              type: 'Multikey',
+              controller: did,
+              publicKeyMultibase: sigMultibase,
+            },
+          ],
+          authentication: [`${did}#${sigMultibase}`],
+          assertionMethod: [`${did}#${sigMultibase}`],
+          capabilityDelegation: [`${did}#${sigMultibase}`],
+          capabilityInvocation: [`${did}#${sigMultibase}`],
+          '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/multikey/v1'],
+        },
+      }
+
+      expect(result).toEqual(expectedResult)
+    })
+
+    it('should resolve with 2019 suite', async () => {
+      const sigMultibase = 'zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169'
+      const did = `did:key:${sigMultibase}`
+      const result = await resolver.resolve(did, { publicKeyFormat: 'EcdsaSecp256r1VerificationKey2019' })
+
+      const expectedResult = {
+        didDocumentMetadata: { contentType: 'application/did+ld+json' },
+        didResolutionMetadata: {},
+        didDocument: {
+          id: did,
+          verificationMethod: [
+            {
+              id: `${did}#${sigMultibase}`,
+              type: 'EcdsaSecp256r1VerificationKey2019',
+              controller: did,
+              publicKeyJwk: {
+                alg: 'ES256',
+                crv: 'P-256',
+                kty: 'EC',
+                use: 'sig',
+                x: 'fyNYMN0976ci7xqiSdag3buk-ZCwgXU4kz9XNkBlNUI',
+                y: 'hW2ojTNfH7Jbi8--CJUo3OCbH3y5n91g-IMA9MLMbTU',
+              },
+            },
+          ],
+          authentication: [`${did}#${sigMultibase}`],
+          assertionMethod: [`${did}#${sigMultibase}`],
+          capabilityDelegation: [`${did}#${sigMultibase}`],
+          capabilityInvocation: [`${did}#${sigMultibase}`],
+          '@context': [
+            'https://www.w3.org/ns/did/v1',
+            {
+              EcdsaSecp256r1VerificationKey2019:
+                'https://w3id.org/security#EcdsaSecp256r1VerificationKey2019',
+              publicKeyJwk: {
+                '@id': 'https://w3id.org/security#publicKeyJwk',
+                '@type': '@json',
+              },
+            },
+          ],
+        },
+      }
+
+      expect(result).toEqual(expectedResult)
+    })
+  })
+})

--- a/packages/did-provider-key/src/resolver.ts
+++ b/packages/did-provider-key/src/resolver.ts
@@ -1,28 +1,290 @@
-import { resolve as resolveED25519 } from '@transmute/did-key-ed25519'
-import { resolve as resolveX25519 } from '@transmute/did-key-x25519'
-import { resolve as resolveSecp256k1 } from '@transmute/did-key-secp256k1'
-import { DIDResolutionOptions, DIDResolutionResult, DIDResolver, ParsedDID, Resolvable } from 'did-resolver'
+import {
+  DIDDocument,
+  DIDResolutionOptions,
+  DIDResolutionResult,
+  DIDResolver,
+  ParsedDID,
+  Resolvable,
+  VerificationMethod,
+} from 'did-resolver'
+import {
+  bytesToBase58,
+  bytesToMultibase,
+  convertEd25519PublicKeyToX25519,
+  createJWK,
+  multibaseToBytes,
+} from '@veramo/utils'
 
-export const startsWithMap: Record<string, Function> = {
-  'did:key:z6Mk': resolveED25519,
+enum SupportedVerificationMethods {
+  'JsonWebKey2020',
+  'Multikey',
+  'EcdsaSecp256k1VerificationKey2019', // deprecated,
+  'EcdsaSecp256k1VerificationKey2020',
+  'Ed25519VerificationKey2020',
+  'Ed25519VerificationKey2018', // deprecated,
+  'X25519KeyAgreementKey2020',
+  'X25519KeyAgreementKey2019', // deprecated,
+  'EcdsaSecp256r1VerificationKey2019',
+}
+
+export type DIDKeyResolverOptions = DIDResolutionOptions & {
+  enableEncryptionKeyDerivation?: boolean // defaults to true
+  publicKeyFormat?: keyof typeof SupportedVerificationMethods // defaults to 'JsonWebKey2020'
+  // experimentalPublicKeyFormat?: false // not supported
+  // defaultContext?: string[] // not supported
+}
+
+const contextFromKeyFormat: Record<keyof typeof SupportedVerificationMethods, string | object> = {
+  JsonWebKey2020: 'https://w3id.org/security/suites/jws-2020/v1',
+  Multikey: 'https://w3id.org/security/multikey/v1',
+  EcdsaSecp256k1VerificationKey2020: 'https://w3id.org/security/suites/secp256k1-2020/v1',
+  EcdsaSecp256k1VerificationKey2019: 'https://w3id.org/security/suites/secp256k1-2019/v1', // deprecated
+  Ed25519VerificationKey2020: 'https://w3id.org/security/suites/ed25519-2020/v1',
+  Ed25519VerificationKey2018: 'https://w3id.org/security/suites/ed25519-2018/v1', // deprecated
+  X25519KeyAgreementKey2020: 'https://w3id.org/security/suites/x25519-2020/v1',
+  X25519KeyAgreementKey2019: 'https://w3id.org/security/suites/x25519-2019/v1', // deprecated
+  EcdsaSecp256r1VerificationKey2019: {
+    EcdsaSecp256r1VerificationKey2019: 'https://w3id.org/security#EcdsaSecp256r1VerificationKey2019',
+    publicKeyJwk: {
+      '@id': 'https://w3id.org/security#publicKeyJwk',
+      '@type': '@json',
+    },
+  },
+}
+
+function resolveECDSA(did: string, options: DIDKeyResolverOptions) {
+  const publicKeyFormat = options?.publicKeyFormat ?? 'JsonWebKey2020'
+  const keyMultibase = did.substring(8)
+  const { keyBytes, keyType } = multibaseToBytes(keyMultibase)
+
+  if (!keyType) {
+    throw new Error(`invalidDid: the key type cannot be deduced for ${did}`)
+  }
+
+  const jwkKeyType = keyType === 'P-256' ? 'Secp256r1' : keyType
+
+  let verificationMethod: VerificationMethod = {
+    id: `${did}#${keyMultibase}`,
+    type: publicKeyFormat,
+    controller: did,
+  }
+  switch (publicKeyFormat) {
+    case 'JsonWebKey2020':
+    case 'EcdsaSecp256r1VerificationKey2019':
+      verificationMethod.publicKeyJwk = createJWK(jwkKeyType as any, keyBytes, 'sig')
+      break
+    case 'Multikey':
+    case 'EcdsaSecp256k1VerificationKey2019':
+    case 'EcdsaSecp256k1VerificationKey2020':
+      verificationMethod.publicKeyMultibase = keyMultibase
+      break
+    default:
+      throw new Error(`invalidPublicKeyType: Unsupported public key format ${publicKeyFormat}`)
+  }
+  let ldContext = {}
+  const acceptedFormat = options.accept ?? 'application/did+ld+json'
+  if (options.accept === 'application/did+json') {
+    ldContext = {}
+  } else if (acceptedFormat === 'application/did+ld+json') {
+    ldContext = {
+      '@context': ['https://www.w3.org/ns/did/v1', contextFromKeyFormat[publicKeyFormat]],
+    }
+  } else {
+    throw new Error(
+      `unsupportedFormat: The DID resolver does not support the requested 'accept' format: ${options.accept}`,
+    )
+  }
+
+  return {
+    didResolutionMetadata: {},
+    didDocumentMetadata: { contentType: options.accept ?? 'application/did+ld+json' },
+    didDocument: {
+      ...ldContext,
+      id: did,
+      verificationMethod: [verificationMethod],
+      authentication: [verificationMethod.id],
+      assertionMethod: [verificationMethod.id],
+      capabilityDelegation: [verificationMethod.id],
+      capabilityInvocation: [verificationMethod.id],
+    },
+  }
+}
+
+function resolveEDDSA(did: string, options: DIDKeyResolverOptions) {
+  const publicKeyFormat = options?.publicKeyFormat ?? 'JsonWebKey2020'
+  const keyMultibase = did.substring(8)
+  const { keyBytes, keyType } = multibaseToBytes(keyMultibase)
+
+  if (!keyType || keyType !== 'Ed25519') {
+    throw new Error(`invalidDid: the key type cannot be deduced for ${did}`)
+  }
+
+  let verificationMethod: VerificationMethod = {
+    id: `${did}#${keyMultibase}`,
+    type: publicKeyFormat,
+    controller: did,
+  }
+  let keyAgreementKeyFormat: keyof typeof SupportedVerificationMethods = publicKeyFormat
+
+  switch (publicKeyFormat) {
+    case 'JsonWebKey2020':
+      verificationMethod.publicKeyJwk = createJWK(keyType as any, keyBytes, 'sig')
+      break
+    case 'Multikey':
+      verificationMethod.publicKeyMultibase = keyMultibase
+      break
+    case 'Ed25519VerificationKey2020':
+      keyAgreementKeyFormat = 'X25519KeyAgreementKey2020'
+      verificationMethod.publicKeyMultibase = keyMultibase
+      break
+    case 'Ed25519VerificationKey2018':
+      keyAgreementKeyFormat = 'X25519KeyAgreementKey2019'
+      verificationMethod.publicKeyBase58 = bytesToBase58(keyBytes)
+      break
+    default:
+      throw new Error(`invalidPublicKeyType: Unsupported public key format ${publicKeyFormat}`)
+  }
+  const ldContextArray: any[] = ['https://www.w3.org/ns/did/v1', contextFromKeyFormat[publicKeyFormat]]
+
+  const result: DIDResolutionResult = {
+    didResolutionMetadata: {},
+    didDocumentMetadata: { contentType: options.accept ?? 'application/did+ld+json' },
+    didDocument: {
+      id: did,
+      verificationMethod: [verificationMethod],
+      authentication: [verificationMethod.id],
+      assertionMethod: [verificationMethod.id],
+      capabilityDelegation: [verificationMethod.id],
+      capabilityInvocation: [verificationMethod.id],
+    },
+  }
+
+  const useEncryptionKey = options.enableEncryptionKeyDerivation ?? true
+
+  if (useEncryptionKey) {
+    const encryptionKeyBytes = convertEd25519PublicKeyToX25519(keyBytes)
+    const encryptionKeyMultibase = bytesToMultibase(encryptionKeyBytes, 'base58btc', 'x25519-pub')
+    const encryptionKey: VerificationMethod = {
+      id: `${did}#${encryptionKeyMultibase}`,
+      type: keyAgreementKeyFormat,
+      controller: did,
+    }
+    if (keyAgreementKeyFormat === 'JsonWebKey2020') {
+      encryptionKey.publicKeyJwk = createJWK('X25519', encryptionKeyBytes, 'enc')
+    } else if (keyAgreementKeyFormat === 'X25519KeyAgreementKey2019') {
+      ldContextArray.push(contextFromKeyFormat[keyAgreementKeyFormat])
+      encryptionKey.publicKeyBase58 = bytesToBase58(encryptionKeyBytes)
+    } else {
+      if (keyAgreementKeyFormat === 'X25519KeyAgreementKey2020') {
+        ldContextArray.push(contextFromKeyFormat[keyAgreementKeyFormat])
+      }
+      encryptionKey.publicKeyMultibase = encryptionKeyMultibase
+    }
+    result.didDocument?.verificationMethod?.push(encryptionKey)
+    result.didDocument!.keyAgreement = [encryptionKey.id]
+  }
+
+  let ldContext = {}
+  const acceptedFormat = options.accept ?? 'application/did+ld+json'
+  if (options.accept === 'application/did+json') {
+    ldContext = {}
+  } else if (acceptedFormat === 'application/did+ld+json') {
+    ldContext = {
+      '@context': ldContextArray,
+    }
+  } else {
+    throw new Error(
+      `unsupportedFormat: The DID resolver does not support the requested 'accept' format: ${options.accept}`,
+    )
+  }
+
+  result.didDocument = { ...result.didDocument, ...ldContext } as DIDDocument
+
+  return result
+}
+
+function resolveX25519(did: string, options: DIDKeyResolverOptions) {
+  const publicKeyFormat = options?.publicKeyFormat ?? 'JsonWebKey2020'
+  const keyMultibase = did.substring(8)
+  const { keyBytes, keyType } = multibaseToBytes(keyMultibase)
+
+  if (!keyType || keyType !== 'X25519') {
+    throw new Error(`invalidDid: the key type cannot be deduced for ${did}`)
+  }
+
+  let verificationMethod: VerificationMethod = {
+    id: `${did}#${keyMultibase}`,
+    type: publicKeyFormat,
+    controller: did,
+  }
+
+  switch (publicKeyFormat) {
+    case 'JsonWebKey2020':
+      verificationMethod.publicKeyJwk = createJWK(keyType as any, keyBytes, 'enc')
+      break
+    case 'Multikey':
+    case 'X25519KeyAgreementKey2020':
+      verificationMethod.publicKeyMultibase = keyMultibase
+      break
+    case 'X25519KeyAgreementKey2019':
+      verificationMethod.publicKeyBase58 = bytesToBase58(keyBytes)
+      break
+    default:
+      throw new Error(`invalidPublicKeyType: Unsupported public key format ${publicKeyFormat}`)
+  }
+  const ldContextArray = ['https://www.w3.org/ns/did/v1', contextFromKeyFormat[publicKeyFormat]]
+
+  const result = {
+    didResolutionMetadata: {},
+    didDocumentMetadata: { contentType: options.accept ?? 'application/did+ld+json' },
+    didDocument: {
+      id: did,
+      verificationMethod: [verificationMethod],
+      keyAgreement: [verificationMethod.id],
+    },
+  }
+
+  let ldContext = {}
+  const acceptedFormat = options.accept ?? 'application/did+ld+json'
+  if (options.accept === 'application/did+json') {
+    ldContext = {}
+  } else if (acceptedFormat === 'application/did+ld+json') {
+    ldContext = {
+      '@context': ldContextArray,
+    }
+  } else {
+    throw new Error(
+      `unsupportedFormat: The DID resolver does not support the requested 'accept' format: ${options.accept}`,
+    )
+  }
+
+  result.didDocument = { ...result.didDocument, ...ldContext }
+
+  return result
+}
+
+export const didPrefixMap: Record<string, Function> = {
+  'did:key:z6Mk': resolveEDDSA,
   'did:key:z6LS': resolveX25519,
-  'did:key:zQ3s': resolveSecp256k1, // compressed Secp256k1 keys
-  'did:key:z7r8': resolveSecp256k1, // uncompressed Secp256k1 keys
+  'did:key:zQ3s': resolveECDSA, // compressed Secp256k1 keys
+  'did:key:z7r8': resolveECDSA, // uncompressed Secp256k1 keys
+  'did:key:zDn': resolveECDSA, // compressed P-256 keys
+  // 'did:key:z82': resolveP384, // compressed P-384 keys - not supported yet
+  // 'did:key:zUC7': resolveBLS12381, // BLS12381 keys - not supported yet
 }
 
 const resolveDidKey: DIDResolver = async (
   didUrl: string,
   _parsed: ParsedDID,
   _resolver: Resolvable,
-  options: DIDResolutionOptions,
+  options: DIDKeyResolverOptions,
 ): Promise<DIDResolutionResult> => {
   try {
-    const startsWith = _parsed.did.substring(0, 12)
-    if (startsWithMap[startsWith] !== undefined) {
-      const didResolution = await startsWithMap[startsWith](didUrl, {
-        ...options,
-        enableEncryptionKeyDerivation: true,
-      })
+    const matchedResolver = Object.keys(didPrefixMap)
+      .filter((prefix) => didUrl.startsWith(prefix))
+      .shift()
+    if (matchedResolver) {
+      const didResolution = await didPrefixMap[matchedResolver](didUrl, options)
       return {
         didDocumentMetadata: {},
         didResolutionMetadata: {},

--- a/packages/did-provider-peer/src/resolver.ts
+++ b/packages/did-provider-peer/src/resolver.ts
@@ -1,6 +1,5 @@
-import { DIDDocument, DIDResolutionResult, DIDResolver, ParsedDID } from 'did-resolver'
+import { DIDDocument, DIDResolutionResult, DIDResolver, ParsedDID, Service } from 'did-resolver'
 import { resolve } from '@aviarytech/did-peer'
-import { IDIDDocumentServiceDescriptor } from '@aviarytech/did-peer/interfaces.js'
 
 /**
  * Creates a DID Resolver that can resolve Peer DIDs (for the 0 and 2 num_algo values)
@@ -24,7 +23,7 @@ export function getResolver(): Record<string, DIDResolver> {
           assertionMethod: doc.assertionMethod,
           capabilityInvocation: doc.capabilityInvocation,
           capabilityDelegation: doc.capabilityDelegation,
-          service: doc.service as IDIDDocumentServiceDescriptor[],
+          service: doc.service as Service[],
         }
         if (doc.alsoKnownAs) {
           didDocument.alsoKnownAs = [doc.alsoKnownAs]

--- a/packages/mediation-manager/src/mediation-manager.ts
+++ b/packages/mediation-manager/src/mediation-manager.ts
@@ -12,7 +12,7 @@ import type {
   IMediationManagerAddRecipientDidArgs,
   RecipientDid,
   IMediationManagerListRecipientDidsArgs,
-} from './types/IMediationManager'
+} from './types/IMediationManager.js'
 import type { IAgentPlugin } from '@veramo/core-types'
 import type { KeyValueStore } from '@veramo/kv-store'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -899,15 +899,6 @@ importers:
 
   packages/did-provider-key:
     dependencies:
-      '@transmute/did-key-ed25519':
-        specifier: ^0.3.0-unstable.10
-        version: 0.3.0-unstable.10(expo@49.0.21)(react-native@0.73.0)
-      '@transmute/did-key-secp256k1':
-        specifier: ^0.3.0-unstable.10
-        version: 0.3.0-unstable.10(expo@49.0.21)(react-native@0.73.0)
-      '@transmute/did-key-x25519':
-        specifier: ^0.3.0-unstable.10
-        version: 0.3.0-unstable.10(expo@49.0.21)(react-native@0.73.0)
       '@veramo/core-types':
         specifier: workspace:^
         version: link:../core-types
@@ -7247,27 +7238,6 @@ packages:
       uri-js: 4.4.1
     dev: false
 
-  /@did-core/data-model@0.1.1-unstable.15:
-    resolution: {integrity: sha512-l7gxLxegcXW7389G+j6o+S24lS8uasmJx5txWpW3QadNvOawKwvWn8bV59SdHSK806xNzIZaCLKmXKxebs8yAQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      factory.ts: 0.5.2
-    dev: false
-
-  /@did-core/did-ld-json@0.1.1-unstable.15(expo@49.0.21)(react-native@0.73.0):
-    resolution: {integrity: sha512-p2jKRxSU+eJJqd+ewCklYp/XZ6ysISk8VU2/kANCoB/WwUy/kVgw2rUNScRDXw2utr9Qj36P8EZTYi4aj7vRCQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      '@transmute/did-context': 0.6.1-unstable.37
-      jsonld-checker: 0.1.8(expo@49.0.21)(react-native@0.73.0)
-    transitivePeerDependencies:
-      - domexception
-      - encoding
-      - expo
-      - react-native
-      - web-streams-polyfill
-    dev: false
-
   /@digitalbazaar/bitstring@3.1.0:
     resolution: {integrity: sha512-Cii+Sl++qaexOvv3vchhgZFfSmtHPNIPzGegaq4ffPnflVXFu+V2qrJ17aL2+gfLxrlC/zazZFuAltyKTPq7eg==}
     engines: {node: '>=16'}
@@ -10599,78 +10569,6 @@ packages:
     resolution: {integrity: sha512-2cB6UcMKeEK6kqvl5Uhpoe5iUUAcVURlRHl9nVa/Xx2JymNHyBvyXi+CGjIwf/eEk7hsgMIwDfGqq5Mcnbk5cw==}
     dev: true
 
-  /@transmute/did-context@0.6.1-unstable.37:
-    resolution: {integrity: sha512-p/QnG3QKS4218hjIDgdvJOFATCXsAnZKgy4egqRrJLlo3Y6OaDBg7cA73dixOwUPoEKob0K6rLIGcsCI/L1acw==}
-    dev: false
-
-  /@transmute/did-key-common@0.3.0-unstable.10(expo@49.0.21)(react-native@0.73.0):
-    resolution: {integrity: sha512-Iryh/HcGIvmTtWFTRaG/JEgbUsqI5OqKqkR2676yQWK4ajLMsyNattz5n0ZfFQk/4U7Ee6pJvvKRduFDAqqV0Q==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@did-core/data-model': 0.1.1-unstable.15
-      '@did-core/did-ld-json': 0.1.1-unstable.15(expo@49.0.21)(react-native@0.73.0)
-      '@transmute/did-context': 0.6.1-unstable.37
-      '@transmute/ld-key-pair': 0.6.1-unstable.37
-      '@transmute/security-context': 0.6.1-unstable.37
-    transitivePeerDependencies:
-      - domexception
-      - encoding
-      - expo
-      - react-native
-      - web-streams-polyfill
-    dev: false
-
-  /@transmute/did-key-ed25519@0.3.0-unstable.10(expo@49.0.21)(react-native@0.73.0):
-    resolution: {integrity: sha512-9QdXl58DjwqBuOJBx6DtvaNW2bZLmVBxMSq2En4RAQcGIz1GGulyEQ1NB7PLIAgnam3LIFxiK6RiQGQTfJmmJg==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@transmute/did-key-common': 0.3.0-unstable.10(expo@49.0.21)(react-native@0.73.0)
-      '@transmute/ed25519-key-pair': 0.6.1-unstable.37
-    transitivePeerDependencies:
-      - domexception
-      - encoding
-      - expo
-      - react-native
-      - web-streams-polyfill
-    dev: false
-
-  /@transmute/did-key-secp256k1@0.3.0-unstable.10(expo@49.0.21)(react-native@0.73.0):
-    resolution: {integrity: sha512-C/Gyu2U3NQZ9Gxu4WVwUk8h0ERbY9Z4Kjk0P49p3IQFrWK19XmVXjA+b1RiqffhYzWJ6fH5TPYIt2LW5MRQmUA==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@transmute/did-key-common': 0.3.0-unstable.10(expo@49.0.21)(react-native@0.73.0)
-      '@transmute/secp256k1-key-pair': 0.7.0-unstable.79
-    transitivePeerDependencies:
-      - domexception
-      - encoding
-      - expo
-      - react-native
-      - web-streams-polyfill
-    dev: false
-
-  /@transmute/did-key-x25519@0.3.0-unstable.10(expo@49.0.21)(react-native@0.73.0):
-    resolution: {integrity: sha512-Jm5UxwI9EhlfVQ9D0Clj9RlMvhOi8nqAgQG30KMzjFMVGfWqIPwQNZFvmL+XsQ7g3dfTo5iQwXBY0de/f+RoMA==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@transmute/did-key-common': 0.3.0-unstable.10(expo@49.0.21)(react-native@0.73.0)
-      '@transmute/x25519-key-pair': 0.7.0-unstable.79
-    transitivePeerDependencies:
-      - domexception
-      - encoding
-      - expo
-      - react-native
-      - web-streams-polyfill
-    dev: false
-
-  /@transmute/ed25519-key-pair@0.6.1-unstable.37:
-    resolution: {integrity: sha512-l34yzE/QnQwmdk5xY9g2kD55e4XPp/jTZQzPu7I6J4Ar+bMaL/0RLL/pgvwyI7qUpsddxRf4WPZCCcZveqPcdA==}
-    engines: {node: '>=10'}
-    dependencies:
-      '@stablelib/ed25519': 1.0.3
-      '@transmute/ld-key-pair': 0.6.1-unstable.37
-      '@transmute/x25519-key-pair': 0.6.1-unstable.37
-    dev: false
-
   /@transmute/ed25519-key-pair@0.7.0-unstable.2:
     resolution: {integrity: sha512-B0jg348Z8F0+lGWQic28xVxBZiXOJYbisWp6EfP4fQdMV3G4sES9YubpdiuoZHjesDZrf6xZ7cEB81mjGJMUkA==}
     engines: {node: '>=10'}
@@ -10747,10 +10645,6 @@ packages:
       - web-streams-polyfill
     dev: false
 
-  /@transmute/ld-key-pair@0.6.1-unstable.37:
-    resolution: {integrity: sha512-DcTpEruAQBfOd2laZkg3uCQ+67Y7dw2hsvo42NAQ5tItCIx5AClP7zccri7T2JUcfDUFaE32z/BLTMEKYt3XZQ==}
-    dev: false
-
   /@transmute/ld-key-pair@0.7.0-unstable.79:
     resolution: {integrity: sha512-QWpzTQStsoD1Bpif1rMWDGlYq0zzsHExw3As8piy3U+MtJpOYIOUJ60L6NSyFBB8Zq+XNeFJq0/puwzMV2lKog==}
     engines: {node: '>=16'}
@@ -10761,15 +10655,6 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
-  /@transmute/secp256k1-key-pair@0.7.0-unstable.79:
-    resolution: {integrity: sha512-Sg9SYya/WMYYT9BDgAS1/wJITJpS1UluUBMk/n3it4YFFqGRrDSDEK9dcEWDHXakv1GfQePpqtuvS2Uv24YgKA==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@bitauth/libauth': 1.19.1
-      '@transmute/ld-key-pair': 0.7.0-unstable.79
-      secp256k1: 4.0.3
-    dev: false
-
   /@transmute/secp256k1-key-pair@0.7.0-unstable.81:
     resolution: {integrity: sha512-kofomMOOLkdTOAV2bQAEZAC0REuiI/RDqxYJJg/qpXnguyGTtv5DVHD8UXmUDKJLJkAql1lbksfs/roYYVBN7g==}
     engines: {node: '>=16'}
@@ -10777,10 +10662,6 @@ packages:
       '@bitauth/libauth': 1.19.1
       '@transmute/ld-key-pair': 0.7.0-unstable.81
       secp256k1: 4.0.3
-    dev: false
-
-  /@transmute/security-context@0.6.1-unstable.37:
-    resolution: {integrity: sha512-GtLmG65qlORrz/2S4I74DT+vA4+qXsFxrMr0cNOXjUqZBd/AW1PTrFnryLF9907BfoiD58HC9qb1WVGWjSlBYw==}
     dev: false
 
   /@transmute/security-context@0.7.0-unstable.81:
@@ -10794,14 +10675,6 @@ packages:
       '@peculiar/webcrypto': 1.4.1
       '@transmute/ld-key-pair': 0.7.0-unstable.81
       big-integer: 1.6.51
-    dev: false
-
-  /@transmute/x25519-key-pair@0.6.1-unstable.37:
-    resolution: {integrity: sha512-j6zR9IoJmgVhUCVH8YVGpsgQf99SxPKZ00LGnUheBAQzgj2lULGBQ44G+GqBCdzfT0qweptTfp1RjqqHEpizeA==}
-    engines: {node: '>=10'}
-    dependencies:
-      '@stablelib/x25519': 1.0.3
-      '@transmute/ld-key-pair': 0.6.1-unstable.37
     dev: false
 
   /@transmute/x25519-key-pair@0.7.0-unstable.79:
@@ -16365,14 +16238,6 @@ packages:
       - supports-color
     dev: true
 
-  /factory.ts@0.5.2:
-    resolution: {integrity: sha512-I4YDKuyMW+s2PocnWh/Ekv9wSStt/MNN1ZRb1qhy0Kv056ndlzbLHDsW9KEmTAqMpLI3BtjSqEdZ7ZfdnaXn9w==}
-    engines: {node: '>= 14'}
-    dependencies:
-      clone-deep: 4.0.1
-      source-map-support: 0.5.21
-    dev: false
-
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -20021,20 +19886,6 @@ packages:
       universalify: 2.0.0
     optionalDependencies:
       graceful-fs: 4.2.11
-
-  /jsonld-checker@0.1.8(expo@49.0.21)(react-native@0.73.0):
-    resolution: {integrity: sha512-jclmnPRrm5SEpaIV6IiSTJxplRAqIWHduQLsUfrYpZM41Ng48m1RN2/aUyHze/ynfO0D2UhlJBt8SdObsH5GBw==}
-    engines: {node: '>=10'}
-    dependencies:
-      jsonld: /@digitalcredentials/jsonld@6.0.0(expo@49.0.21)(react-native@0.73.0)
-      node-fetch: 2.6.12
-    transitivePeerDependencies:
-      - domexception
-      - encoding
-      - expo
-      - react-native
-      - web-streams-polyfill
-    dev: false
 
   /jsonld-signatures@11.2.1(expo@49.0.21)(react-native@0.73.0):
     resolution: {integrity: sha512-RNaHTEeRrX0jWeidPCwxMq/E/Ze94zFyEZz/v267ObbCHQlXhPO7GtkY6N5PSHQfQhZPXa8NlMBg5LiDF4dNbA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -510,8 +510,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       credential-status:
-        specifier: ^2.0.5
-        version: 2.0.5
+        specifier: ^3.0.0
+        version: 3.0.0
       did-jwt:
         specifier: ^8.0.0
         version: 8.0.0
@@ -14342,6 +14342,13 @@ packages:
       did-jwt: 6.11.6
       did-resolver: 4.1.0
     dev: true
+
+  /credential-status@3.0.0:
+    resolution: {integrity: sha512-kCHyxp+dtFVV1wy0auNZXwWWLIUmQTuw6uFLfdm5aRaN5JUWyR2Bv6aHLszB8sxEwRYgL6bqfQAUVCXTWo61jw==}
+    dependencies:
+      did-jwt: 8.0.0
+      did-resolver: 4.1.0
+    dev: false
 
   /credentials-context@2.0.0:
     resolution: {integrity: sha512-/mFKax6FK26KjgV2KW2D4YqKgoJ5DVJpNt87X2Jc9IxT2HBMy7nEIlc+n7pEi+YFFe721XqrvZPd+jbyyBjsvQ==}


### PR DESCRIPTION
## What issue is this PR fixing

fixes #1330

## What is being changed

The did:key resolver implementations imported from transmute resolved to outdated Verification method formats.
This PR replaces those dependencies with a local implementation that also adheres better to the spec for defaults and behavior.

The verification methods default to `JsonWebKey2020`, unless otherwise specified through the `options.publicKeyFormat` parameter.
This implementation also supports `options.enableEncryptionKeyDerivation`, defaulting to `true`, that triggers the expression of the corresponding X25519 `keyAgreement` key for an Ed25519 public key.

This implementation supports `Ed25519`, `X25519`, `Secp256k1`, and `P-256` key types for did:key.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [X] I added unit tests.
* [ ] I added integration tests.

## Notes

This PR is based on #1331, as changing the default verification methods in did:key triggers the corner case signaled in #1329 and fixed in #1331