### PR TITLE
fix(credential-w3c): forward DID resolution options to the resolver

### DIFF
--- a/__tests__/localAgent.test.ts
+++ b/__tests__/localAgent.test.ts
@@ -32,6 +32,8 @@ import {
   LdDefaultContexts,
   VeramoEcdsaSecp256k1RecoverySignature2020,
   VeramoEd25519Signature2018,
+  VeramoEd25519Signature2020,
+  VeramoJsonWebSignature2020,
 } from '../packages/credential-ld/src'
 import { EthrDIDProvider } from '../packages/did-provider-ethr/src'
 import { WebDIDProvider } from '../packages/did-provider-web/src'
@@ -245,12 +247,17 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
           new SdrMessageHandler(),
         ],
       }),
-      new DIDComm({ transports: [new DIDCommHttpTransport()]}),
+      new DIDComm({ transports: [new DIDCommHttpTransport()] }),
       new CredentialPlugin(),
       new CredentialIssuerEIP712(),
       new CredentialIssuerLD({
         contextMaps: [LdDefaultContexts, credential_contexts as any],
-        suites: [new VeramoEcdsaSecp256k1RecoverySignature2020(), new VeramoEd25519Signature2018()],
+        suites: [
+          new VeramoEcdsaSecp256k1RecoverySignature2020(),
+          new VeramoEd25519Signature2018(),
+          new VeramoJsonWebSignature2020(),
+          new VeramoEd25519Signature2020(),
+        ],
       }),
       new SelectiveDisclosure(),
       new DIDDiscovery({

--- a/__tests__/localJsonStoreAgent.test.ts
+++ b/__tests__/localJsonStoreAgent.test.ts
@@ -30,6 +30,8 @@ import {
   LdDefaultContexts,
   VeramoEcdsaSecp256k1RecoverySignature2020,
   VeramoEd25519Signature2018,
+  VeramoEd25519Signature2020,
+  VeramoJsonWebSignature2020,
 } from '../packages/credential-ld/src'
 import { EthrDIDProvider } from '../packages/did-provider-ethr/src'
 import { WebDIDProvider } from '../packages/did-provider-web/src'
@@ -51,7 +53,7 @@ import {
   PrivateKeyStoreJson,
 } from '../packages/data-store-json/src'
 import { FakeDidProvider, FakeDidResolver } from '../packages/test-utils/src'
-import { PeerDIDProvider, getResolver as getDidPeerResolver } from '../packages/did-provider-peer/src'
+import { getResolver as getDidPeerResolver, PeerDIDProvider } from '../packages/did-provider-peer/src'
 
 import { Resolver } from 'did-resolver'
 import { getResolver as ethrDidResolver } from 'ethr-did-resolver'
@@ -77,7 +79,7 @@ import utils from './shared/utils'
 import { JsonFileStore } from './utils/json-file-store'
 import credentialStatus from './shared/credentialStatus'
 import credentialPluginTests from './shared/credentialPluginTests'
-import dbInitOptions from "./shared/dbInitOptions";
+import dbInitOptions from './shared/dbInitOptions'
 
 jest.setTimeout(120000)
 
@@ -205,7 +207,12 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
       new CredentialIssuerEIP712(),
       new CredentialIssuerLD({
         contextMaps: [LdDefaultContexts, credential_contexts as any],
-        suites: [new VeramoEcdsaSecp256k1RecoverySignature2020(), new VeramoEd25519Signature2018()],
+        suites: [
+          new VeramoEcdsaSecp256k1RecoverySignature2020(),
+          new VeramoEd25519Signature2018(),
+          new VeramoEd25519Signature2020(),
+          new VeramoJsonWebSignature2020(),
+        ],
       }),
       new SelectiveDisclosure(),
       ...(options?.plugins || []),

--- a/__tests__/restAgent.test.ts
+++ b/__tests__/restAgent.test.ts
@@ -19,10 +19,7 @@ import {
   IResolver,
   TAgent,
 } from '../packages/core-types/src'
-import {
-  Agent,
-  createAgent
-} from '../packages/core/src'
+import { Agent, createAgent } from '../packages/core/src'
 import { MessageHandler } from '../packages/message-handler/src'
 import { KeyManager } from '../packages/key-manager/src'
 import { AliasDiscoveryProvider, DIDManager } from '../packages/did-manager/src'
@@ -41,13 +38,15 @@ import {
   LdDefaultContexts,
   VeramoEcdsaSecp256k1RecoverySignature2020,
   VeramoEd25519Signature2018,
+  VeramoEd25519Signature2020,
+  VeramoJsonWebSignature2020,
 } from '../packages/credential-ld/src'
 import { EthrDIDProvider } from '../packages/did-provider-ethr/src'
 import { WebDIDProvider } from '../packages/did-provider-web/src'
 import { getDidKeyResolver, KeyDIDProvider } from '../packages/did-provider-key/src'
 import { getDidPkhResolver, PkhDIDProvider } from '../packages/did-provider-pkh/src'
 import { getDidJwkResolver, JwkDIDProvider } from '../packages/did-provider-jwk/src'
-import { getResolver as getDidPeerResolver, PeerDIDProvider } from "../packages/did-provider-peer/src";
+import { getResolver as getDidPeerResolver, PeerDIDProvider } from '../packages/did-provider-peer/src'
 import { DIDComm, DIDCommHttpTransport, DIDCommMessageHandler, IDIDComm } from '../packages/did-comm/src'
 import {
   ISelectiveDisclosure,
@@ -99,7 +98,7 @@ import messageHandler from './shared/messageHandler'
 import didDiscovery from './shared/didDiscovery'
 import utils from './shared/utils'
 import credentialStatus from './shared/credentialStatus'
-import credentialPluginTests from "./shared/credentialPluginTests";
+import credentialPluginTests from './shared/credentialPluginTests'
 
 jest.setTimeout(120000)
 
@@ -197,7 +196,7 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
             defaultKms: 'local',
           }),
           'did:peer': new PeerDIDProvider({
-            defaultKms: 'local'
+            defaultKms: 'local',
           }),
           'did:pkh': new PkhDIDProvider({
             defaultKms: 'local',
@@ -230,13 +229,18 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
           new SdrMessageHandler(),
         ],
       }),
-      new DIDComm({ transports: [new DIDCommHttpTransport()]}),
+      new DIDComm({ transports: [new DIDCommHttpTransport()] }),
       // intentionally use the deprecated name to test compatibility
       new CredentialIssuer(),
       new CredentialIssuerEIP712(),
       new CredentialIssuerLD({
         contextMaps: [LdDefaultContexts, credential_contexts as any],
-        suites: [new VeramoEcdsaSecp256k1RecoverySignature2020(), new VeramoEd25519Signature2018()],
+        suites: [
+          new VeramoEcdsaSecp256k1RecoverySignature2020(),
+          new VeramoEd25519Signature2018(),
+          new VeramoJsonWebSignature2020(),
+          new VeramoEd25519Signature2020(),
+        ],
       }),
       new SelectiveDisclosure(),
       new DIDDiscovery({

--- a/packages/core-types/src/plugin.schema.ts
+++ b/packages/core-types/src/plugin.schema.ts
@@ -4218,6 +4218,18 @@ export const schema = {
         "ICreateVerifiableCredentialArgs": {
           "type": "object",
           "properties": {
+            "resolutionOptions": {
+              "type": "object",
+              "properties": {
+                "publicKeyFormat": {
+                  "type": "string"
+                },
+                "accept": {
+                  "type": "string"
+                }
+              },
+              "description": "Options to be passed to the DID resolver."
+            },
             "credential": {
               "$ref": "#/components/schemas/CredentialPayload",
               "description": "The JSON payload of the Credential according to the\n {@link  https://www.w3.org/TR/vc-data-model/#credentials | canonical model } \n\nThe signer of the Credential is chosen based on the `issuer.id` property of the `credential`\n\n`@context`, `type` and `issuanceDate` will be added automatically if omitted"
@@ -4432,6 +4444,18 @@ export const schema = {
         "ICreateVerifiablePresentationArgs": {
           "type": "object",
           "properties": {
+            "resolutionOptions": {
+              "type": "object",
+              "properties": {
+                "publicKeyFormat": {
+                  "type": "string"
+                },
+                "accept": {
+                  "type": "string"
+                }
+              },
+              "description": "Options to be passed to the DID resolver."
+            },
             "presentation": {
               "$ref": "#/components/schemas/PresentationPayload",
               "description": "The JSON payload of the Presentation according to the\n {@link  https://www.w3.org/TR/vc-data-model/#presentations | canonical model } .\n\nThe signer of the Presentation is chosen based on the `holder` property of the `presentation`\n\n`@context`, `type` and `issuanceDate` will be added automatically if omitted"
@@ -4788,6 +4812,18 @@ export const schema = {
         "IVerifyCredentialArgs": {
           "type": "object",
           "properties": {
+            "resolutionOptions": {
+              "type": "object",
+              "properties": {
+                "publicKeyFormat": {
+                  "type": "string"
+                },
+                "accept": {
+                  "type": "string"
+                }
+              },
+              "description": "Options to be passed to the DID resolver."
+            },
             "credential": {
               "$ref": "#/components/schemas/W3CVerifiableCredential",
               "description": "The Verifiable Credential object according to the\n {@link  https://www.w3.org/TR/vc-data-model/#credentials | canonical model }  or the JWT representation.\n\nThe signer of the Credential is verified based on the `issuer.id` property of the `credential` or the `iss` property of the JWT payload respectively"
@@ -5017,6 +5053,18 @@ export const schema = {
         "IVerifyPresentationArgs": {
           "type": "object",
           "properties": {
+            "resolutionOptions": {
+              "type": "object",
+              "properties": {
+                "publicKeyFormat": {
+                  "type": "string"
+                },
+                "accept": {
+                  "type": "string"
+                }
+              },
+              "description": "Options to be passed to the DID resolver."
+            },
             "presentation": {
               "$ref": "#/components/schemas/W3CVerifiablePresentation",
               "description": "The Verifiable Presentation object according to the\n {@link  https://www.w3.org/TR/vc-data-model/#presentations | canonical model }  or the JWT representation.\n\nThe signer of the Presentation is verified based on the `holder` property of the `presentation` or the `iss` property of the JWT payload respectively"
@@ -5152,6 +5200,18 @@ export const schema = {
         "ICheckCredentialStatusArgs": {
           "type": "object",
           "properties": {
+            "resolutionOptions": {
+              "type": "object",
+              "properties": {
+                "publicKeyFormat": {
+                  "type": "string"
+                },
+                "accept": {
+                  "type": "string"
+                }
+              },
+              "description": "Options to be passed to the DID resolver."
+            },
             "credential": {
               "$ref": "#/components/schemas/VerifiableCredential",
               "description": "The credential whose status needs to be checked"

--- a/packages/core-types/src/types/ICredentialIssuer.ts
+++ b/packages/core-types/src/types/ICredentialIssuer.ts
@@ -10,6 +10,7 @@ import { IDIDManager } from './IDIDManager.js'
 import { IDataStore } from './IDataStore.js'
 import { IKeyManager } from './IKeyManager.js'
 import { IIdentifier, IKey } from "./IIdentifier.js";
+import { UsingResolutionOptions } from './ICredentialVerifier.js'
 
 /**
  * The type of encoding to be used for the Verifiable Credential or Presentation to be generated.
@@ -26,7 +27,7 @@ export type ProofFormat = 'jwt' | 'lds' | 'EthereumEip712Signature2021'
  *
  * @public
  */
-export interface ICreateVerifiablePresentationArgs {
+export interface ICreateVerifiablePresentationArgs extends UsingResolutionOptions {
   /**
    * The JSON payload of the Presentation according to the
    * {@link https://www.w3.org/TR/vc-data-model/#presentations | canonical model}.
@@ -97,7 +98,7 @@ export interface ICreateVerifiablePresentationArgs {
  *
  * @public
  */
-export interface ICreateVerifiableCredentialArgs {
+export interface ICreateVerifiableCredentialArgs extends UsingResolutionOptions {
   /**
    * The JSON payload of the Credential according to the
    * {@link https://www.w3.org/TR/vc-data-model/#credentials | canonical model}

--- a/packages/core-types/src/types/ICredentialStatusVerifier.ts
+++ b/packages/core-types/src/types/ICredentialStatusVerifier.ts
@@ -2,6 +2,7 @@ import { DIDDocument } from 'did-resolver'
 import { IAgentContext, IPluginMethodMap } from './IAgent.js'
 import { VerifiableCredential, CredentialStatus } from './vc-data-model.js'
 import { IResolver } from './IResolver.js'
+import { UsingResolutionOptions } from './ICredentialVerifier.js'
 
 /**
  * Arguments for calling {@link ICredentialStatusVerifier.checkCredentialStatus | checkCredentialStatus}.
@@ -12,7 +13,7 @@ import { IResolver } from './IResolver.js'
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
-export interface ICheckCredentialStatusArgs {
+export interface ICheckCredentialStatusArgs extends UsingResolutionOptions {
   /**
    * The credential whose status needs to be checked
    */

--- a/packages/core-types/src/types/ICredentialVerifier.ts
+++ b/packages/core-types/src/types/ICredentialVerifier.ts
@@ -3,6 +3,21 @@ import { IVerifyResult } from './IVerifyResult.js'
 import { W3CVerifiableCredential, W3CVerifiablePresentation } from './vc-data-model.js'
 import { IResolver } from './IResolver.js'
 import { IDIDManager } from './IDIDManager.js'
+import { DIDResolutionOptions } from 'did-resolver'
+
+/**
+ * Options that are forwarded to the DID resolver.
+ * @public
+ */
+export interface UsingResolutionOptions {
+  /**
+   * Options to be passed to the DID resolver.
+   */
+  resolutionOptions?: DIDResolutionOptions & {
+    // Used by did:key to determine the format of the public key. Specified here for discoverability.
+    publicKeyFormat?: string
+  }
+}
 
 /**
  * Encapsulates the parameters required to verify a
@@ -10,7 +25,7 @@ import { IDIDManager } from './IDIDManager.js'
  *
  * @public
  */
-export interface IVerifyCredentialArgs {
+export interface IVerifyCredentialArgs extends UsingResolutionOptions {
   /**
    * The Verifiable Credential object according to the
    * {@link https://www.w3.org/TR/vc-data-model/#credentials | canonical model} or the JWT representation.
@@ -48,7 +63,7 @@ export interface IVerifyCredentialArgs {
  *
  * @public
  */
-export interface IVerifyPresentationArgs {
+export interface IVerifyPresentationArgs extends UsingResolutionOptions {
   /**
    * The Verifiable Presentation object according to the
    * {@link https://www.w3.org/TR/vc-data-model/#presentations | canonical model} or the JWT representation.

--- a/packages/credential-eip712/src/agent/CredentialEIP712.ts
+++ b/packages/credential-eip712/src/agent/CredentialEIP712.ts
@@ -84,7 +84,12 @@ export class CredentialIssuerEIP712 implements IAgentPlugin {
       keyRef = key.kid
     }
 
-    const extendedKeys = await mapIdentifierKeysToDoc(identifier, 'verificationMethod', context)
+    const extendedKeys = await mapIdentifierKeysToDoc(
+      identifier,
+      'verificationMethod',
+      context,
+      args.resolutionOptions,
+    )
     const extendedKey = extendedKeys.find((key) => key.kid === keyRef)
     if (!extendedKey)
       throw Error('key_not_found: The signing key is not available in the issuer DID document')
@@ -147,7 +152,7 @@ export class CredentialIssuerEIP712 implements IAgentPlugin {
     const verificationMessage = {
       ...signingInput,
       proof: verifyInputProof,
-   }
+    }
 
     const compat = {
       ...eip712Domain,
@@ -177,7 +182,7 @@ export class CredentialIssuerEIP712 implements IAgentPlugin {
       throw new Error('invalid_argument: credential.issuer must not be empty')
     }
 
-    const didDocument = await resolveDidOrThrow(issuer, context)
+    const didDocument = await resolveDidOrThrow(issuer, context, args.resolutionOptions)
 
     if (didDocument.verificationMethod) {
       for (const verificationMethod of didDocument.verificationMethod) {
@@ -251,11 +256,16 @@ export class CredentialIssuerEIP712 implements IAgentPlugin {
       keyRef = key.kid
     }
 
-    const extendedKeys = await mapIdentifierKeysToDoc(identifier, 'verificationMethod', context)
+    const extendedKeys = await mapIdentifierKeysToDoc(
+      identifier,
+      'verificationMethod',
+      context,
+      args.resolutionOptions,
+    )
     const extendedKey = extendedKeys.find((key) => key.kid === keyRef)
     if (!extendedKey)
       throw Error('key_not_found: The signing key is not available in the issuer DID document')
-    
+
     let chainId
     try {
       chainId = getChainId(extendedKey.meta.verificationMethod)
@@ -339,7 +349,7 @@ export class CredentialIssuerEIP712 implements IAgentPlugin {
       throw new Error('invalid_argument: args.presentation.issuer must not be empty')
     }
 
-    const didDocument = await resolveDidOrThrow(issuer, context)
+    const didDocument = await resolveDidOrThrow(issuer, context, args.resolutionOptions)
 
     if (didDocument.verificationMethod) {
       for (const verificationMethod of didDocument.verificationMethod) {

--- a/packages/credential-eip712/src/plugin.schema.ts
+++ b/packages/credential-eip712/src/plugin.schema.ts
@@ -5,6 +5,18 @@ export const schema = {
         "ICreateVerifiableCredentialEIP712Args": {
           "type": "object",
           "properties": {
+            "resolutionOptions": {
+              "type": "object",
+              "properties": {
+                "publicKeyFormat": {
+                  "type": "string"
+                },
+                "accept": {
+                  "type": "string"
+                }
+              },
+              "description": "Options to be passed to the DID resolver."
+            },
             "credential": {
               "$ref": "#/components/schemas/CredentialPayload",
               "description": "The json payload of the Credential according to the\n {@link  https://www.w3.org/TR/vc-data-model/#credentials | canonical model } \n\nThe signer of the Credential is chosen based on the `issuer.id` property of the `credential`\n\n`@context`, 'type' and 'issuanceDate' will be added automatically if omitted"
@@ -189,6 +201,18 @@ export const schema = {
         "ICreateVerifiablePresentationEIP712Args": {
           "type": "object",
           "properties": {
+            "resolutionOptions": {
+              "type": "object",
+              "properties": {
+                "publicKeyFormat": {
+                  "type": "string"
+                },
+                "accept": {
+                  "type": "string"
+                }
+              },
+              "description": "Options to be passed to the DID resolver."
+            },
             "presentation": {
               "$ref": "#/components/schemas/PresentationPayload",
               "description": "The json payload of the Presentation according to the\n {@link  https://www.w3.org/TR/vc-data-model/#presentations | canonical model } .\n\nThe signer of the Presentation is chosen based on the `holder` property of the `presentation`\n\n`@context`, `type` and `issuanceDate` will be added automatically if omitted"
@@ -317,6 +341,18 @@ export const schema = {
         "IVerifyCredentialEIP712Args": {
           "type": "object",
           "properties": {
+            "resolutionOptions": {
+              "type": "object",
+              "properties": {
+                "publicKeyFormat": {
+                  "type": "string"
+                },
+                "accept": {
+                  "type": "string"
+                }
+              },
+              "description": "Options to be passed to the DID resolver."
+            },
             "credential": {
               "$ref": "#/components/schemas/VerifiableCredential",
               "description": "The json payload of the Credential according to the\n {@link  https://www.w3.org/TR/vc-data-model/#credentials | canonical model } \n\nThe signer of the Credential is chosen based on the `issuer.id` property of the `credential`"
@@ -330,6 +366,18 @@ export const schema = {
         "IVerifyPresentationEIP712Args": {
           "type": "object",
           "properties": {
+            "resolutionOptions": {
+              "type": "object",
+              "properties": {
+                "publicKeyFormat": {
+                  "type": "string"
+                },
+                "accept": {
+                  "type": "string"
+                }
+              },
+              "description": "Options to be passed to the DID resolver."
+            },
             "presentation": {
               "$ref": "#/components/schemas/VerifiablePresentation",
               "description": "The Verifiable Presentation object according to the\n {@link  https://www.w3.org/TR/vc-data-model/#presentations | canonical model }  or the JWT representation.\n\nThe signer of the Presentation is verified based on the `holder` property of the `presentation` or the `iss` property of the JWT payload respectively"

--- a/packages/credential-eip712/src/types/ICredentialEIP712.ts
+++ b/packages/credential-eip712/src/types/ICredentialEIP712.ts
@@ -7,6 +7,7 @@ import {
   IPluginMethodMap,
   IResolver,
   PresentationPayload,
+  UsingResolutionOptions,
   VerifiableCredential,
   VerifiablePresentation,
 } from '@veramo/core-types'
@@ -103,7 +104,7 @@ export interface ICredentialIssuerEIP712 extends IPluginMethodMap {
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
-export interface ICreateVerifiableCredentialEIP712Args {
+export interface ICreateVerifiableCredentialEIP712Args extends UsingResolutionOptions {
   /**
    * The json payload of the Credential according to the
    * {@link https://www.w3.org/TR/vc-data-model/#credentials | canonical model}
@@ -129,7 +130,7 @@ export interface ICreateVerifiableCredentialEIP712Args {
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
-export interface ICreateVerifiablePresentationEIP712Args {
+export interface ICreateVerifiablePresentationEIP712Args extends UsingResolutionOptions {
   /**
    * The json payload of the Presentation according to the
    * {@link https://www.w3.org/TR/vc-data-model/#presentations | canonical model}.
@@ -154,7 +155,7 @@ export interface ICreateVerifiablePresentationEIP712Args {
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
-export interface IVerifyCredentialEIP712Args {
+export interface IVerifyCredentialEIP712Args extends UsingResolutionOptions {
   /**
    * The json payload of the Credential according to the
    * {@link https://www.w3.org/TR/vc-data-model/#credentials | canonical model}
@@ -172,7 +173,7 @@ export interface IVerifyCredentialEIP712Args {
  *
  * @public
  */
-export interface IVerifyPresentationEIP712Args {
+export interface IVerifyPresentationEIP712Args extends UsingResolutionOptions {
   /**
    * The Verifiable Presentation object according to the
    * {@link https://www.w3.org/TR/vc-data-model/#presentations | canonical model} or the JWT representation.

--- a/packages/credential-ld/src/action-handler.ts
+++ b/packages/credential-ld/src/action-handler.ts
@@ -37,6 +37,7 @@ import {
   IVerifyCredentialLDArgs,
   IVerifyPresentationLDArgs,
 } from './types.js'
+import { DIDResolutionOptions } from 'did-resolver'
 
 const debug = Debug('veramo:credential-ld:action-handler')
 
@@ -114,6 +115,7 @@ export class CredentialIssuerLD implements IAgentPlugin {
         context,
         identifier,
         args.keyRef,
+        args.resolutionOptions,
       )
 
       let { now } = args
@@ -169,6 +171,7 @@ export class CredentialIssuerLD implements IAgentPlugin {
         context,
         identifier,
         args.keyRef,
+        args.resolutionOptions,
       )
 
       let { now } = args
@@ -202,12 +205,7 @@ export class CredentialIssuerLD implements IAgentPlugin {
       now = new Date(now * 1000)
     }
 
-    return this.ldCredentialModule.verifyCredential(
-      credential,
-      args.fetchRemoteContexts || false,
-      { ...args, now },
-      context,
-    )
+    return this.ldCredentialModule.verifyCredential(credential, { ...args, now }, context)
   }
 
   /** {@inheritdoc ICredentialIssuerLD.verifyPresentationLD} */
@@ -224,7 +222,6 @@ export class CredentialIssuerLD implements IAgentPlugin {
       presentation,
       args.challenge,
       args.domain,
-      args.fetchRemoteContexts || false,
       { ...args, now },
       context,
     )
@@ -234,8 +231,14 @@ export class CredentialIssuerLD implements IAgentPlugin {
     context: IAgentContext<IResolver>,
     identifier: IIdentifier,
     keyRef?: string,
+    resolutionOptions?: DIDResolutionOptions,
   ): Promise<{ signingKey: _ExtendedIKey; verificationMethodId: string }> {
-    const extendedKeys: _ExtendedIKey[] = await mapIdentifierKeysToDoc(identifier, 'assertionMethod', context)
+    const extendedKeys: _ExtendedIKey[] = await mapIdentifierKeysToDoc(
+      identifier,
+      'assertionMethod',
+      context,
+      resolutionOptions,
+    )
     let supportedTypes = this.ldCredentialModule.ldSuiteLoader.getAllSignatureSuiteTypes()
     let signingKey: _ExtendedIKey | undefined
     let verificationMethodId: string
@@ -264,7 +267,7 @@ export class CredentialIssuerLD implements IAgentPlugin {
 
   /**
    * Returns true if the key is supported by any of the installed LD Signature suites
-   * @param k - the key to verify
+   * @param k - the key to match
    *
    * @internal
    */

--- a/packages/credential-ld/src/plugin.schema.ts
+++ b/packages/credential-ld/src/plugin.schema.ts
@@ -5,6 +5,18 @@ export const schema = {
         "ICreateVerifiableCredentialLDArgs": {
           "type": "object",
           "properties": {
+            "resolutionOptions": {
+              "type": "object",
+              "properties": {
+                "publicKeyFormat": {
+                  "type": "string"
+                },
+                "accept": {
+                  "type": "string"
+                }
+              },
+              "description": "Options to be passed to the DID resolver."
+            },
             "credential": {
               "$ref": "#/components/schemas/CredentialPayload",
               "description": "The json payload of the Credential according to the\n {@link  https://www.w3.org/TR/vc-data-model/#credentials | canonical model } \n\nThe signer of the Credential is chosen based on the `issuer.id` property of the `credential`\n\n`@context`, `type` and `issuanceDate` will be added automatically if omitted"
@@ -196,6 +208,18 @@ export const schema = {
         "ICreateVerifiablePresentationLDArgs": {
           "type": "object",
           "properties": {
+            "resolutionOptions": {
+              "type": "object",
+              "properties": {
+                "publicKeyFormat": {
+                  "type": "string"
+                },
+                "accept": {
+                  "type": "string"
+                }
+              },
+              "description": "Options to be passed to the DID resolver."
+            },
             "presentation": {
               "$ref": "#/components/schemas/PresentationPayload",
               "description": "The json payload of the Presentation according to the\n {@link  https://www.w3.org/TR/vc-data-model/#presentations | canonical model } .\n\nThe signer of the Presentation is chosen based on the `holder` property of the `presentation`\n\n`@context`, `type` and `issuanceDate` will be added automatically if omitted."
@@ -339,6 +363,18 @@ export const schema = {
         "IVerifyCredentialLDArgs": {
           "type": "object",
           "properties": {
+            "resolutionOptions": {
+              "type": "object",
+              "properties": {
+                "publicKeyFormat": {
+                  "type": "string"
+                },
+                "accept": {
+                  "type": "string"
+                }
+              },
+              "description": "Options to be passed to the DID resolver."
+            },
             "credential": {
               "$ref": "#/components/schemas/VerifiableCredential",
               "description": "The json payload of the Credential according to the\n {@link  https://www.w3.org/TR/vc-data-model/#credentials | canonical model } \n\nThe signer of the Credential is chosen based on the `issuer.id` property of the `credential`"
@@ -359,6 +395,18 @@ export const schema = {
         "IVerifyPresentationLDArgs": {
           "type": "object",
           "properties": {
+            "resolutionOptions": {
+              "type": "object",
+              "properties": {
+                "publicKeyFormat": {
+                  "type": "string"
+                },
+                "accept": {
+                  "type": "string"
+                }
+              },
+              "description": "Options to be passed to the DID resolver."
+            },
             "presentation": {
               "$ref": "#/components/schemas/VerifiablePresentation",
               "description": "The json payload of the Credential according to the\n {@link  https://www.w3.org/TR/vc-data-model/#credentials | canonical model } \n\nThe signer of the Credential is chosen based on the `issuer.id` property of the `credential`"

--- a/packages/credential-ld/src/types.ts
+++ b/packages/credential-ld/src/types.ts
@@ -7,6 +7,7 @@ import {
   IPluginMethodMap,
   IResolver,
   PresentationPayload,
+  UsingResolutionOptions,
   VerifiableCredential,
   VerifiablePresentation,
 } from '@veramo/core-types'
@@ -104,7 +105,7 @@ export interface ICredentialIssuerLD extends IPluginMethodMap {
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
-export interface ICreateVerifiablePresentationLDArgs {
+export interface ICreateVerifiablePresentationLDArgs extends UsingResolutionOptions {
   /**
    * The json payload of the Presentation according to the
    * {@link https://www.w3.org/TR/vc-data-model/#presentations | canonical model}.
@@ -150,7 +151,7 @@ export interface ICreateVerifiablePresentationLDArgs {
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
-export interface ICreateVerifiableCredentialLDArgs {
+export interface ICreateVerifiableCredentialLDArgs extends UsingResolutionOptions {
   /**
    * The json payload of the Credential according to the
    * {@link https://www.w3.org/TR/vc-data-model/#credentials | canonical model}
@@ -186,7 +187,7 @@ export interface ICreateVerifiableCredentialLDArgs {
  *
  * @beta This API may change without a BREAKING CHANGE notice
  */
-export interface IVerifyCredentialLDArgs {
+export interface IVerifyCredentialLDArgs extends UsingResolutionOptions {
   /**
    * The json payload of the Credential according to the
    * {@link https://www.w3.org/TR/vc-data-model/#credentials | canonical model}
@@ -216,7 +217,7 @@ export interface IVerifyCredentialLDArgs {
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
-export interface IVerifyPresentationLDArgs {
+export interface IVerifyPresentationLDArgs extends UsingResolutionOptions {
   /**
    * The json payload of the Credential according to the
    * {@link https://www.w3.org/TR/vc-data-model/#credentials | canonical model}

--- a/packages/credential-status/src/credential-status.ts
+++ b/packages/credential-status/src/credential-status.ts
@@ -42,7 +42,7 @@ export class CredentialStatusPlugin implements IAgentPlugin {
     let didDoc = args.didDocumentOverride
     if (!didDoc) {
       const issuerDid = extractIssuer(args.credential)
-      didDoc = await resolveDidOrThrow(issuerDid, context)
+      didDoc = await resolveDidOrThrow(issuerDid, context, args.resolutionOptions)
     }
     const statusCheck: CredentialStatus = (await this.status.checkStatus(
       args.credential,

--- a/packages/credential-w3c/src/action-handler.ts
+++ b/packages/credential-w3c/src/action-handler.ts
@@ -283,7 +283,13 @@ export class CredentialPlugin implements IAgentPlugin {
     if (type == DocumentFormat.JWT) {
       let jwt: string = typeof credential === 'string' ? credential : credential.proof.jwt
 
-      const resolver = { resolve: (didUrl: string) => context.agent.resolveDid({ didUrl }) } as Resolvable
+      const resolver = {
+        resolve: (didUrl: string) =>
+          context.agent.resolveDid({
+            didUrl,
+            options: otherOptions?.resolutionOptions,
+          }),
+      } as Resolvable
       try {
         // needs broader credential as well to check equivalence with jwt
         verificationResult = await verifyCredentialJWT(jwt, resolver, {
@@ -398,7 +404,13 @@ export class CredentialPlugin implements IAgentPlugin {
       } else {
         jwt = presentation.proof.jwt
       }
-      const resolver = { resolve: (didUrl: string) => context.agent.resolveDid({ didUrl }) } as Resolvable
+      const resolver = {
+        resolve: (didUrl: string) =>
+          context.agent.resolveDid({
+            didUrl,
+            options: otherOptions?.resolutionOptions,
+          }),
+      } as Resolvable
 
       let audience = domain
       if (!audience) {

--- a/packages/did-comm/src/plugin.schema.ts
+++ b/packages/did-comm/src/plugin.schema.ts
@@ -26,6 +26,18 @@ export const schema = {
         "IPackDIDCommMessageArgs": {
           "type": "object",
           "properties": {
+            "resolutionOptions": {
+              "type": "object",
+              "properties": {
+                "publicKeyFormat": {
+                  "type": "string"
+                },
+                "accept": {
+                  "type": "string"
+                }
+              },
+              "description": "Options to be passed to the DID resolver."
+            },
             "message": {
               "$ref": "#/components/schemas/IDIDCommMessage"
             },
@@ -204,6 +216,18 @@ export const schema = {
         "ISendDIDCommMessageArgs": {
           "type": "object",
           "properties": {
+            "resolutionOptions": {
+              "type": "object",
+              "properties": {
+                "publicKeyFormat": {
+                  "type": "string"
+                },
+                "accept": {
+                  "type": "string"
+                }
+              },
+              "description": "Options to be passed to the DID resolver."
+            },
             "packedMessage": {
               "$ref": "#/components/schemas/IPackedDIDCommMessage"
             },
@@ -663,7 +687,27 @@ export const schema = {
           "deprecated": "Please use {@link IDIDComm.sendDIDCommMessage } instead. This will be removed in Veramo 4.0.\nInput arguments for {@link IDIDComm.sendMessageDIDCommAlpha1 }"
         },
         "IUnpackDIDCommMessageArgs": {
-          "$ref": "#/components/schemas/IPackedDIDCommMessage",
+          "type": "object",
+          "properties": {
+            "resolutionOptions": {
+              "type": "object",
+              "properties": {
+                "publicKeyFormat": {
+                  "type": "string"
+                },
+                "accept": {
+                  "type": "string"
+                }
+              },
+              "description": "Options to be passed to the DID resolver."
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "message"
+          ],
           "description": "The input to the  {@link  IDIDComm.unpackDIDCommMessage }  method."
         },
         "IUnpackedDIDCommMessage": {

--- a/packages/did-comm/src/types/IDIDComm.ts
+++ b/packages/did-comm/src/types/IDIDComm.ts
@@ -6,6 +6,7 @@ import {
   IMessageHandler,
   IPluginMethodMap,
   IResolver,
+  UsingResolutionOptions,
 } from '@veramo/core-types'
 import { ISendMessageDIDCommAlpha1Args } from '../didcomm.js'
 import {
@@ -22,7 +23,7 @@ import {
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
-export type IUnpackDIDCommMessageArgs = IPackedDIDCommMessage
+export type IUnpackDIDCommMessageArgs = IPackedDIDCommMessage & UsingResolutionOptions
 
 /**
  * The input to the {@link IDIDComm.packDIDCommMessage} method.
@@ -30,7 +31,7 @@ export type IUnpackDIDCommMessageArgs = IPackedDIDCommMessage
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
-export interface IPackDIDCommMessageArgs {
+export interface IPackDIDCommMessageArgs extends UsingResolutionOptions {
   message: IDIDCommMessage
   packing: DIDCommMessagePacking
   keyRef?: string
@@ -44,7 +45,7 @@ export interface IPackDIDCommMessageArgs {
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
-export interface ISendDIDCommMessageArgs {
+export interface ISendDIDCommMessageArgs extends UsingResolutionOptions {
   packedMessage: IPackedDIDCommMessage
   messageId: string
   returnTransportId?: string

--- a/packages/did-comm/src/utils.ts
+++ b/packages/did-comm/src/utils.ts
@@ -1,6 +1,6 @@
 import { IAgentContext, IDIDManager, IIdentifier, IKeyManager, IResolver, TKeyType } from '@veramo/core-types'
 import { ECDH, JWE } from 'did-jwt'
-import { parse as parseDidUrl } from 'did-resolver'
+import { DIDResolutionOptions, parse as parseDidUrl } from 'did-resolver'
 
 import Debug from 'debug'
 import {
@@ -31,11 +31,12 @@ export function createEcdhWrapper(secretKeyRef: string, context: IAgentContext<I
 export async function extractSenderEncryptionKey(
   jwe: JWE,
   context: IAgentContext<IResolver>,
+  resolutionOptions?: DIDResolutionOptions,
 ): Promise<Uint8Array | null> {
   let senderKey: Uint8Array | null = null
   const protectedHeader = decodeJoseBlob(jwe.protected)
   if (typeof protectedHeader.skid === 'string') {
-    const senderDoc = await resolveDidOrThrow(protectedHeader.skid, context)
+    const senderDoc = await resolveDidOrThrow(protectedHeader.skid, context, resolutionOptions)
     const sKey = (await context.agent.getDIDComponentById({
       didDocument: senderDoc,
       didUrl: protectedHeader.skid,
@@ -85,11 +86,17 @@ export async function extractManagedRecipients(
 export async function mapRecipientsToLocalKeys(
   managedKeys: { recipient: any; kid: string; identifier: IIdentifier }[],
   context: IAgentContext<IResolver>,
+  resolutionOptions?: DIDResolutionOptions,
 ): Promise<{ localKeyRef: string; recipient: any }[]> {
   const potentialKeys = await Promise.all(
     managedKeys.map(async ({ recipient, kid, identifier }) => {
       // TODO: use caching, since all recipients are supposed to belong to the same identifier
-      const identifierKeys = await mapIdentifierKeysToDoc(identifier, 'keyAgreement', context)
+      const identifierKeys = await mapIdentifierKeysToDoc(
+        identifier,
+        'keyAgreement',
+        context,
+        resolutionOptions,
+      )
       const localKey = identifierKeys.find((key) => key.meta.verificationMethod.id === kid)
       if (localKey) {
         return { localKeyRef: localKey.kid, recipient }

--- a/packages/test-react-app/src/veramo/setup.ts
+++ b/packages/test-react-app/src/veramo/setup.ts
@@ -27,6 +27,8 @@ import {
   LdDefaultContexts,
   VeramoEcdsaSecp256k1RecoverySignature2020,
   VeramoEd25519Signature2018,
+  VeramoEd25519Signature2020,
+  VeramoJsonWebSignature2020,
 } from '@veramo/credential-ld'
 import { getDidKeyResolver, KeyDIDProvider } from '@veramo/did-provider-key'
 import { getResolver as getDidPeerResolver, PeerDIDProvider } from '@veramo/did-provider-peer'
@@ -150,7 +152,12 @@ export function getAgent(options?: IAgentOptions): TAgent<InstalledPlugins> {
       new CredentialPlugin(),
       new CredentialIssuerLD({
         contextMaps: [LdDefaultContexts],
-        suites: [new VeramoEcdsaSecp256k1RecoverySignature2020(), new VeramoEd25519Signature2018()],
+        suites: [
+          new VeramoEcdsaSecp256k1RecoverySignature2020(),
+          new VeramoEd25519Signature2018(),
+          new VeramoEd25519Signature2020(),
+          new VeramoJsonWebSignature2020(),
+        ],
       }),
       new SelectiveDisclosure(),
       ...(options?.plugins || []),


### PR DESCRIPTION
## What issue is this PR fixing

fixes #1343

## What is being changed
Plugin methods that rely on did-resolver can now accept an optional `resolutionOptions` parameter that gets forwarded to the DID resolver.

Affected packages:
`@veramo/credential-w3c`
`@veramo/credential-ld`
`@veramo/credential-eip712`
`@veramo/did-comm`

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [X] I added integration tests.
