### PR TITLE
fix(cli): remove `revocable` and `send` options from credential create command

### DIFF
--- a/packages/cli/default/default.yml
+++ b/packages/cli/default/default.yml
@@ -277,6 +277,8 @@ credentialIssuerLD:
   $args:
     - suites:
         - $require: '@veramo/credential-ld#VeramoEd25519Signature2018'
+        - $require: '@veramo/credential-ld#VeramoEd25519Signature2020'
+        - $require: '@veramo/credential-ld#VeramoJsonWebSignature2020'
         - $require: '@veramo/credential-ld#VeramoEcdsaSecp256k1RecoverySignature2020'
       contextMaps:
         # The LdDefaultContext is a "catch-all" for now.


### PR DESCRIPTION
## What issue is this PR fixing

fixes #1342

## What is being changed

The `veramo credential create` command would ask if the credential being created should be revokable but would then use an incompletely supported credentialStatus method, making the credentials unverifiable (using default configs).
Since the command is (still) meant as a simple demo, it's easier to simply remove that option.

Additionally, the credential is now getting saved using data-store API instead of the deprecated `save` option and the verification is a bit more lenient with JSON5 inputs.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because we don't yet have a test harness for the CLI, and I am aware that a PR without tests will likely get rejected.
