### PR TITLE
fix(cli): remove interactive prompting on CLI execute command

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "json-schema": "0.4.0",
     "lerna": "7.3.0",
     "lerna-changelog": "2.2.0",
-    "oas-resolver": "2.5.6",
     "openapi-types": "12.1.3",
     "prettier": "3.0.2",
     "rimraf": "5.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -84,7 +84,6 @@
     "json-schema": "^0.4.0",
     "json5": "^2.2.3",
     "jsonpointer": "^5.0.1",
-    "oas-resolver": "^2.5.6",
     "openapi-types": "^12.1.3",
     "passport": "^0.6.0",
     "passport-http-bearer": "^1.0.1",

--- a/packages/cli/src/imported-types/imported-modules.d.ts
+++ b/packages/cli/src/imported-types/imported-modules.d.ts
@@ -1,2 +1,1 @@
 declare module 'cors'
-declare module 'oas-resolver'

--- a/packages/credential-w3c/src/action-handler.ts
+++ b/packages/credential-w3c/src/action-handler.ts
@@ -485,10 +485,10 @@ export class CredentialPlugin implements IAgentPlugin {
 
   /**
    * Checks if a key is suitable for signing JWT payloads.
-   * @param key
-   * @param context
+   * @param key - the key to check for support
+   * @param context - This reserved param is automatically added and handled by the framework, *do not override*
    *
-   * @internal
+   * @beta
    */
   async matchKeyForJWT(key: IKey, context: IssuerAgentContext): Promise<boolean> {
     switch (key.type) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,9 +105,6 @@ importers:
       lerna-changelog:
         specifier: 2.2.0
         version: 2.2.0
-      oas-resolver:
-        specifier: 2.5.6
-        version: 2.5.6
       openapi-types:
         specifier: 12.1.3
         version: 12.1.3
@@ -300,9 +297,6 @@ importers:
       jsonpointer:
         specifier: ^5.0.1
         version: 5.0.1
-      oas-resolver:
-        specifier: ^2.5.6
-        version: 2.5.6
       openapi-types:
         specifier: ^12.1.3
         version: 12.1.3
@@ -15802,6 +15796,7 @@ packages:
     dependencies:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
+    bundledDependencies: false
 
   /ethr-did-resolver@10.1.0:
     resolution: {integrity: sha512-PH3R8UQGpJGWXaVVSWPppPiEzb7eHrzG6yTCGtk23Fw8Et2totj+7V1id+zxCQvToM9cW+CHA/+k64F8xpk/Mw==}
@@ -16282,9 +16277,6 @@ packages:
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
-
-  /fast-safe-stringify@2.1.1:
-    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   /fast-text-encoding@1.0.6:
     resolution: {integrity: sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==}
@@ -17623,9 +17615,6 @@ packages:
     transitivePeerDependencies:
       - debug
     dev: true
-
-  /http2-client@1.3.5:
-    resolution: {integrity: sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==}
 
   /https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -21476,12 +21465,6 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /node-fetch-h2@2.3.0:
-    resolution: {integrity: sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==}
-    engines: {node: 4.x || >=6.0.0}
-    dependencies:
-      http2-client: 1.3.5
-
   /node-fetch@2.6.12:
     resolution: {integrity: sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==}
     engines: {node: 4.x || >=6.0.0}
@@ -21973,21 +21956,6 @@ packages:
     transitivePeerDependencies:
       - debug
     dev: true
-
-  /oas-kit-common@1.0.8:
-    resolution: {integrity: sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==}
-    dependencies:
-      fast-safe-stringify: 2.1.1
-
-  /oas-resolver@2.5.6:
-    resolution: {integrity: sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==}
-    hasBin: true
-    dependencies:
-      node-fetch-h2: 2.3.0
-      oas-kit-common: 1.0.8
-      reftools: 1.1.9
-      yaml: 1.10.2
-      yargs: 17.7.2
 
   /ob1@0.80.1:
     resolution: {integrity: sha512-o9eYflOo+QnbC/k9GYQuAy90zOGQ/OBgrjlIeW6VrKhevSxth83JSdEvKuKaV7SMGJVQhSY3Zp8eGa3g0rLP0A==}
@@ -24451,9 +24419,6 @@ packages:
 
   /reflect-metadata@0.1.13:
     resolution: {integrity: sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==}
-
-  /reftools@1.1.9:
-    resolution: {integrity: sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==}
 
   /regenerate-unicode-properties@10.1.0:
     resolution: {integrity: sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==}
@@ -27774,6 +27739,7 @@ packages:
   /yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
+    dev: true
 
   /yaml@2.3.1:
     resolution: {integrity: sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==}


### PR DESCRIPTION
## What issue is this PR fixing

fixes #1281

## What is being changed

When calling `veramo execute` without parameters, the CLI will no longer offer a list of available methods based on `oas-resolver`.

Also, the `execute` command is now using `Debug` instead of `console.log` for logging, so that the console can be used for stdout and piping. Example: `veramo execute -m didManagerFind -a '{}' | jq '.[0].did'` to get the DID of the first identifier managed locally.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because there is still no test harness for CLI, and I am aware that a PR without tests will likely get rejected.

## Details

The discussion in #1281 lead to the decision to remove this functionality from the CLI