### PR TITLE
fix: address edge case when getting DIDDoc component

### DIFF
--- a/packages/did-resolver/src/__tests__/resolver.test.ts
+++ b/packages/did-resolver/src/__tests__/resolver.test.ts
@@ -1,5 +1,5 @@
 import { DIDResolverPlugin } from '../resolver.js'
-import { Resolver } from 'did-resolver'
+import { Resolver, VerificationMethod } from 'did-resolver'
 
 describe('@veramo/did-resolver', () => {
   it('should throw error when misconfigured', () => {
@@ -14,5 +14,91 @@ describe('@veramo/did-resolver', () => {
   it('should have resolve method', () => {
     const resolver = new DIDResolverPlugin({ resolver: new Resolver() })
     expect(resolver).toHaveProperty('resolveDid')
+  })
+
+  const didDoc1 = {
+    '@context':["https://www.w3.org/ns/did/v1","https://w3id.org/security/multikey/v1",
+      // line below causes TS issue but isn't used in getDIDComponentById
+      // {"@base":"did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ"}
+    ],
+    "id":"did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ",
+    "verificationMethod":[
+      {"id":"#key-2","type":"Multikey","controller":"did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ","publicKeyMultibase":"z6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff"},
+      {"id":"#key-1","type":"Multikey","controller":"did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ","publicKeyMultibase":"z6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA"}
+    ],
+    "keyAgreement":["#key-1"],
+    "authentication":["#key-2"],
+    "assertionMethod":["#key-2"],
+    "service":[{"id":"1","description":"a DIDComm endpoint","serviceEndpoint":"did:web:dev-didcomm-mediator.herokuapp.com","type":"DIDCommMessaging"}]
+  }
+  
+  it('should correctly get component by key suffix with key in verificationMethod as suffix only', async () => {
+    const resolver = new DIDResolverPlugin({ resolver: new Resolver() })
+    const result = await resolver.getDIDComponentById({ didDocument: didDoc1, section: 'keyAgreement', didUrl: '#key-1'})
+    expect((result.valueOf()as VerificationMethod).id).toEqual("did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ#key-1")
+  })
+  
+  const didDoc2 = {
+    "@context":["https://www.w3.org/ns/did/v1","https://w3id.org/security/multikey/v1",
+      // {"@base":"did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ"}
+    ],
+    "id":"did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ",
+    "verificationMethod":[
+      {"id":"#key-2","type":"Multikey","controller":"did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ","publicKeyMultibase":"z6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff"},
+      {"id":"did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ#key-1","type":"Multikey","controller":"did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ","publicKeyMultibase":"z6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA"}
+    ],
+    "keyAgreement":["#key-1"],
+    "authentication":["#key-2"],
+    "assertionMethod":["#key-2"],
+    "service":[{"id":"1","description":"a DIDComm endpoint","serviceEndpoint":"did:web:dev-didcomm-mediator.herokuapp.com","type":"DIDCommMessaging"}]
+  }  
+
+  it('should correctly get component by key suffix with key in verificationMethod as DID + suffix', async () => {
+    const resolver = new DIDResolverPlugin({ resolver: new Resolver() })
+    const result = await resolver.getDIDComponentById({ didDocument: didDoc2, section: 'keyAgreement', didUrl: '#key-1'})
+    expect((result.valueOf()as VerificationMethod).id).toEqual("did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ#key-1")
+  })
+
+  const didDoc3 = {
+    "@context":["https://www.w3.org/ns/did/v1","https://w3id.org/security/multikey/v1",
+      // {"@base":"did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ"}
+    ],
+    "id":"did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ",
+    "verificationMethod":[
+      {"id":"#key-2","type":"Multikey","controller":"did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ","publicKeyMultibase":"z6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff"},
+      {"id":"did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ#key-1","type":"Multikey","controller":"did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ","publicKeyMultibase":"z6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA"}
+    ],
+    "keyAgreement":["#key-1"],
+    "authentication":["#key-2"],
+    "assertionMethod":["#key-2"],
+    "service":[{"id":"1","description":"a DIDComm endpoint","serviceEndpoint":"did:web:dev-didcomm-mediator.herokuapp.com","type":"DIDCommMessaging"}]
+  }  
+
+  it('should correctly get component by DID + key suffix with key in verificationMethod as DID + suffix', async () => {
+    const resolver = new DIDResolverPlugin({ resolver: new Resolver() })
+    const result = await resolver.getDIDComponentById({ didDocument: didDoc3, section: 'keyAgreement', didUrl: 'did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ#key-1'})
+    expect((result.valueOf()as VerificationMethod).id).toEqual("did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ#key-1")
+  })
+
+  
+  const didDoc4 = {
+    "@context":["https://www.w3.org/ns/did/v1","https://w3id.org/security/multikey/v1",
+      // {"@base":"did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ"}
+    ],
+    "id":"did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ",
+    "verificationMethod":[
+      {"id":"#key-2","type":"Multikey","controller":"did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ","publicKeyMultibase":"z6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff"},
+      {"id":"#key-1","type":"Multikey","controller":"did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ","publicKeyMultibase":"z6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA"}
+    ],
+    "keyAgreement":["#key-1"],
+    "authentication":["#key-2"],
+    "assertionMethod":["#key-2"],
+    "service":[{"id":"1","description":"a DIDComm endpoint","serviceEndpoint":"did:web:dev-didcomm-mediator.herokuapp.com","type":"DIDCommMessaging"}]
+  }  
+
+  it('should correctly get component by DID + key suffix with key in verificationMethod as suffix only', async () => {
+    const resolver = new DIDResolverPlugin({ resolver: new Resolver() })
+    const result = await resolver.getDIDComponentById({ didDocument: didDoc4, section: 'keyAgreement', didUrl: 'did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ#key-1'})
+    expect((result.valueOf()as VerificationMethod).id).toEqual("did:peer:2.Ez6LSiNkZ4hS9ivnKXcEf1GGfXxqcWSCCXaFC775JZjVfwkoA.Vz6Mkr6TpZKXqdt4Kx28GSrLt4VysTWof6Npm4HNaGMcVPTff.SeyJpZCI6IjEiLCJ0IjoiZG0iLCJzIjoiZGlkOndlYjpkZXYtZGlkY29tbS1tZWRpYXRvci5oZXJva3VhcHAuY29tIiwiZGVzY3JpcHRpb24iOiJhIERJRENvbW0gZW5kcG9pbnQifQ#key-1")
   })
 })

--- a/packages/did-resolver/src/resolver.ts
+++ b/packages/did-resolver/src/resolver.ts
@@ -100,7 +100,7 @@ export class DIDResolverPlugin implements IAgentPlugin {
       }
     })
     if (typeof result === 'string') {
-      result = mainSections.find((item) => item.id === didUrl || `${did}${item.id}` === didUrl)
+      result = mainSections.find((item) => item.id === didUrl || `${did}${item.id}` === didUrl || item.id === `${did}${didUrl}`);
     }
 
     if (!result) {


### PR DESCRIPTION
## What issue is this PR fixing

`fixes #1364`

## What is being changed
The `getDIDComponentById` function in `did-resolver/src/resolver.ts` is modified so that it correctly finds the result when the `didUrl` passed in is a keyID without the DID prefixed to it, but the resolved DID Document lists the key with the prefix.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [ ] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because I am unable to reproduce this error in unit tests, and I am aware that a PR without tests will likely get rejected.

## Details
it's possible that this is not the ideal solution and the proper fix for the bug is upstream from this function
