### PR TITLE
feat(credential-w3c): added support bbs proof format

### DIFF
--- a/packages/core-types/src/types/ICredentialIssuer.ts
+++ b/packages/core-types/src/types/ICredentialIssuer.ts
@@ -19,7 +19,7 @@ import { UsingResolutionOptions } from './ICredentialVerifier.js'
  *
  * @public
  */
-export type ProofFormat = 'jwt' | 'lds' | 'EthereumEip712Signature2021'
+export type ProofFormat = 'jwt' | 'lds' | 'EthereumEip712Signature2021' | 'bbs'
 
 /**
  * Encapsulates the parameters required to create a


### PR DESCRIPTION
## What is being changed
This PR extends the credential-w3c actionHandler logic by adding support for bbs signatures.
In this way, it will be possible to generate plugins that implement the creation of Verifiable Credentials and Verifiable Presentations, as well as their verification using bbs-type signatures.

According to what was discussed here:
[https://discord.com/channels/878293684620234752/1220477267172659360/1227352488579961003](https://discord.com/channels/878293684620234752/1220477267172659360/1227352488579961003)

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.

## Details
These changes only extend the logic of the action-handler, they do not include the implementation of the plugin.
