### PR TITLE
perf: replace TypeOrm `findOne` queries including relations with `find`

### DIFF
--- a/packages/data-store/src/data-store.ts
+++ b/packages/data-store/src/data-store.ts
@@ -63,7 +63,7 @@ export class DataStore implements IAgentPlugin {
   }
 
   async dataStoreGetMessage(args: IDataStoreGetMessageArgs): Promise<IMessage> {
-    const messageEntity = await (await getConnectedDb(this.dbConnection)).getRepository(Message).findOne({
+    const [messageEntity] = await (await getConnectedDb(this.dbConnection)).getRepository(Message).find({
       where: { id: args.id },
       relations: ['credentials', 'presentations'],
     })
@@ -73,7 +73,7 @@ export class DataStore implements IAgentPlugin {
   }
 
   async dataStoreDeleteMessage(args: IDataStoreDeleteMessageArgs): Promise<boolean> {
-    const messageEntity = await (await getConnectedDb(this.dbConnection)).getRepository(Message).findOne({
+    const [messageEntity] = await (await getConnectedDb(this.dbConnection)).getRepository(Message).find({
       where: { id: args.id },
       relations: ['credentials', 'presentations'],
     })

--- a/packages/data-store/src/identifier/did-store.ts
+++ b/packages/data-store/src/identifier/did-store.ts
@@ -48,7 +48,7 @@ export class DIDStore extends AbstractDIDStore {
       throw Error('[veramo:data-store:identifier-store] Get requires did or (alias and provider)')
     }
 
-    const identifier = await (await getConnectedDb(this.dbConnection)).getRepository(Identifier).findOne({
+    const [identifier] = await (await getConnectedDb(this.dbConnection)).getRepository(Identifier).find({
       where,
       relations: ['keys', 'services'],
     })
@@ -88,7 +88,7 @@ export class DIDStore extends AbstractDIDStore {
   }
 
   async deleteDID({ did }: { did: string }) {
-    const identifier = await (await getConnectedDb(this.dbConnection)).getRepository(Identifier).findOne({
+    const [identifier] = await (await getConnectedDb(this.dbConnection)).getRepository(Identifier).find({
       where: { did },
       relations: ['keys', 'services', 'issuedCredentials', 'issuedPresentations'],
     })


### PR DESCRIPTION
## What issue is this PR fixing

This PR addresses a performance issue with TypeORM (https://github.com/typeorm/typeorm/issues/5694) 

When using `findOne()` with attached relations, TypeORM executes two queries:

```
query: SELECT DISTINCT "distinctAlias"."Identifier_did" AS "ids_Identifier_did" FROM (SELECT "Identifier"."did" AS "Identifier_did", "Identifier"."provider" AS "Identifier_provider", "Identifier"."alias" AS "Identifier_alias", "Identifier"."controllerKeyId" AS "Identifier_controllerKeyId", "Identifier__Identifier_keys"."kid" AS "Identifier__Identifier_keys_kid", "Identifier__Identifier_keys"."kms" AS "Identifier__Identifier_keys_kms", "Identifier__Identifier_keys"."type" AS "Identifier__Identifier_keys_type", "Identifier__Identifier_keys"."publicKeyHex" AS "Identifier__Identifier_keys_publicKeyHex", "Identifier__Identifier_keys"."meta" AS "Identifier__Identifier_keys_meta", "Identifier__Identifier_keys"."identifierDid" AS "Identifier__Identifier_keys_identifierDid", "Identifier__Identifier_services"."id" AS "Identifier__Identifier_services_id", "Identifier__Identifier_services"."type" AS "Identifier__Identifier_services_type", "Identifier__Identifier_services"."serviceEndpoint" AS "Identifier__Identifier_services_serviceEndpoint", "Identifier__Identifier_services"."description" AS "Identifier__Identifier_services_description", "Identifier__Identifier_services"."identifierDid" AS "Identifier__Identifier_services_identifierDid" FROM "identifier" "Identifier" LEFT JOIN "key" "Identifier__Identifier_keys" ON "Identifier__Identifier_keys"."identifierDid"="Identifier"."did"  LEFT JOIN "service" "Identifier__Identifier_services" ON "Identifier__Identifier_services"."identifierDid"="Identifier"."did" WHERE (("Identifier"."did" = $1))) "distinctAlias" ORDER BY "Identifier_did" ASC LIMIT 1 -- PARAMETERS: ["did:ethr:xyz"]
query: SELECT "Identifier"."did" AS "Identifier_did", "Identifier"."provider" AS "Identifier_provider", "Identifier"."alias" AS "Identifier_alias", "Identifier"."controllerKeyId" AS "Identifier_controllerKeyId", "Identifier__Identifier_keys"."kid" AS "Identifier__Identifier_keys_kid", "Identifier__Identifier_keys"."kms" AS "Identifier__Identifier_keys_kms", "Identifier__Identifier_keys"."type" AS "Identifier__Identifier_keys_type", "Identifier__Identifier_keys"."publicKeyHex" AS "Identifier__Identifier_keys_publicKeyHex", "Identifier__Identifier_keys"."meta" AS "Identifier__Identifier_keys_meta", "Identifier__Identifier_keys"."identifierDid" AS "Identifier__Identifier_keys_identifierDid", "Identifier__Identifier_services"."id" AS "Identifier__Identifier_services_id", "Identifier__Identifier_services"."type" AS "Identifier__Identifier_services_type", "Identifier__Identifier_services"."serviceEndpoint" AS "Identifier__Identifier_services_serviceEndpoint", "Identifier__Identifier_services"."description" AS "Identifier__Identifier_services_description", "Identifier__Identifier_services"."identifierDid" AS "Identifier__Identifier_services_identifierDid" FROM "identifier" "Identifier" LEFT JOIN "key" "Identifier__Identifier_keys" ON "Identifier__Identifier_keys"."identifierDid"="Identifier"."did"  LEFT JOIN "service" "Identifier__Identifier_services" ON "Identifier__Identifier_services"."identifierDid"="Identifier"."did" WHERE ( (("Identifier"."did" = $1)) ) AND ( "Identifier"."did" IN ($2) ) -- PARAMETERS: ["did:ethr:xyz","did:ethr:xyz"]
```

the two queries are specially gaining performance when doing pagination (where we have skip and take). In the datastore we explicitly don't want/need to page, just getting the first entry back.

When executing the query with just a "find" and taking the first element in the array, TypeORM executes only one query:

```
query: SELECT "Identifier"."did" AS "Identifier_did", "Identifier"."provider" AS "Identifier_provider", "Identifier"."alias" AS "Identifier_alias", "Identifier"."controllerKeyId" AS "Identifier_controllerKeyId", "Identifier__Identifier_keys"."kid" AS "Identifier__Identifier_keys_kid", "Identifier__Identifier_keys"."kms" AS "Identifier__Identifier_keys_kms", "Identifier__Identifier_keys"."type" AS "Identifier__Identifier_keys_type", "Identifier__Identifier_keys"."publicKeyHex" AS "Identifier__Identifier_keys_publicKeyHex", "Identifier__Identifier_keys"."meta" AS "Identifier__Identifier_keys_meta", "Identifier__Identifier_keys"."identifierDid" AS "Identifier__Identifier_keys_identifierDid", "Identifier__Identifier_services"."id" AS "Identifier__Identifier_services_id", "Identifier__Identifier_services"."type" AS "Identifier__Identifier_services_type", "Identifier__Identifier_services"."serviceEndpoint" AS "Identifier__Identifier_services_serviceEndpoint", "Identifier__Identifier_services"."description" AS "Identifier__Identifier_services_description", "Identifier__Identifier_services"."identifierDid" AS "Identifier__Identifier_services_identifierDid" FROM "identifier" "Identifier" LEFT JOIN "key" "Identifier__Identifier_keys" ON "Identifier__Identifier_keys"."identifierDid"="Identifier"."did"  LEFT JOIN "service" "Identifier__Identifier_services" ON "Identifier__Identifier_services"."identifierDid"="Identifier"."did" WHERE (("Identifier"."did" = $1)) -- PARAMETERS: ["did:ethr:xyz"]
```
This results in a performance boost when generating VPs (in our case the "find" executes in half of the time as with "findOne")

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because no logic was changed, and I am aware that a PR without tests will likely get rejected.
