### PR TITLE
chore(did-resolver): remove integration tests that rely on non-operational service

### DIFF
--- a/packages/did-resolver/src/__tests__/integration.test.ts
+++ b/packages/did-resolver/src/__tests__/integration.test.ts
@@ -31,39 +31,39 @@ let resolverPlugin: DIDResolverPlugin = new DIDResolverPlugin({ resolver })
 let resolverPluginDirect: DIDResolverPlugin = new DIDResolverPlugin(resolverMap)
 
 describe('@veramo/did-resolver', () => {
-  beforeAll(() => {})
+  beforeAll(() => { })
 
-  it('should resolve web DID', async () => {
-    expect.assertions(1)
-    await expect(resolverPlugin.resolveDid({ didUrl: 'did:web:did.actor:alice' })).resolves.toEqual({
-      didDocument: {
-        '@context': ['https://w3.org/ns/did/v1', 'https://w3id.org/security/suites/ed25519-2018/v1'],
-        id: 'did:web:did.actor:alice',
-        publicKey: [
-          {
-            id: 'did:web:did.actor:alice#z6MkrmNwty5ajKtFqc1U48oL2MMLjWjartwc5sf2AihZwXDN',
-            controller: 'did:web:did.actor:alice',
-            type: 'Ed25519VerificationKey2018',
-            publicKeyBase58: 'DK7uJiq9PnPnj7AmNZqVBFoLuwTjT1hFPrk6LSjZ2JRz',
-          },
-        ],
-        authentication: ['did:web:did.actor:alice#z6MkrmNwty5ajKtFqc1U48oL2MMLjWjartwc5sf2AihZwXDN'],
-        assertionMethod: ['did:web:did.actor:alice#z6MkrmNwty5ajKtFqc1U48oL2MMLjWjartwc5sf2AihZwXDN'],
-        capabilityDelegation: ['did:web:did.actor:alice#z6MkrmNwty5ajKtFqc1U48oL2MMLjWjartwc5sf2AihZwXDN'],
-        capabilityInvocation: ['did:web:did.actor:alice#z6MkrmNwty5ajKtFqc1U48oL2MMLjWjartwc5sf2AihZwXDN'],
-        keyAgreement: [
-          {
-            id: 'did:web:did.actor:alice#zC8GybikEfyNaausDA4mkT4egP7SNLx2T1d1kujLQbcP6h',
-            type: 'X25519KeyAgreementKey2019',
-            controller: 'did:web:did.actor:alice',
-            publicKeyBase58: 'CaSHXEvLKS6SfN9aBfkVGBpp15jSnaHazqHgLHp8KZ3Y',
-          },
-        ],
-      },
-      didDocumentMetadata: {},
-      didResolutionMetadata: { contentType: 'application/did+ld+json' },
-    })
-  })
+  // it('should resolve web DID', async () => {
+  //   expect.assertions(1)
+  //   await expect(resolverPlugin.resolveDid({ didUrl: 'did:web:did.actor:alice' })).resolves.toEqual({
+  //     didDocument: {
+  //       '@context': ['https://w3.org/ns/did/v1', 'https://w3id.org/security/suites/ed25519-2018/v1'],
+  //       id: 'did:web:did.actor:alice',
+  //       publicKey: [
+  //         {
+  //           id: 'did:web:did.actor:alice#z6MkrmNwty5ajKtFqc1U48oL2MMLjWjartwc5sf2AihZwXDN',
+  //           controller: 'did:web:did.actor:alice',
+  //           type: 'Ed25519VerificationKey2018',
+  //           publicKeyBase58: 'DK7uJiq9PnPnj7AmNZqVBFoLuwTjT1hFPrk6LSjZ2JRz',
+  //         },
+  //       ],
+  //       authentication: ['did:web:did.actor:alice#z6MkrmNwty5ajKtFqc1U48oL2MMLjWjartwc5sf2AihZwXDN'],
+  //       assertionMethod: ['did:web:did.actor:alice#z6MkrmNwty5ajKtFqc1U48oL2MMLjWjartwc5sf2AihZwXDN'],
+  //       capabilityDelegation: ['did:web:did.actor:alice#z6MkrmNwty5ajKtFqc1U48oL2MMLjWjartwc5sf2AihZwXDN'],
+  //       capabilityInvocation: ['did:web:did.actor:alice#z6MkrmNwty5ajKtFqc1U48oL2MMLjWjartwc5sf2AihZwXDN'],
+  //       keyAgreement: [
+  //         {
+  //           id: 'did:web:did.actor:alice#zC8GybikEfyNaausDA4mkT4egP7SNLx2T1d1kujLQbcP6h',
+  //           type: 'X25519KeyAgreementKey2019',
+  //           controller: 'did:web:did.actor:alice',
+  //           publicKeyBase58: 'CaSHXEvLKS6SfN9aBfkVGBpp15jSnaHazqHgLHp8KZ3Y',
+  //         },
+  //       ],
+  //     },
+  //     didDocumentMetadata: {},
+  //     didResolutionMetadata: { contentType: 'application/did+ld+json' },
+  //   })
+  // })
 
   it('should resolve ethr-did with RPC URL', async () => {
     expect.assertions(1)
@@ -89,11 +89,11 @@ describe('@veramo/did-resolver', () => {
     })
   })
 
-  it('should resolve web DID using direct constructor', async () => {
-    expect.assertions(1)
-    const result = await resolverPluginDirect.resolveDid({ didUrl: 'did:web:did.actor:alice' })
-    expect(result?.didDocument?.id).toEqual('did:web:did.actor:alice')
-  })
+  // it('should resolve web DID using direct constructor', async () => {
+  //   expect.assertions(1)
+  //   const result = await resolverPluginDirect.resolveDid({ didUrl: 'did:web:did.actor:alice' })
+  //   expect(result?.didDocument?.id).toEqual('did:web:did.actor:alice')
+  // })
 
   it('should resolve ethr-did with RPC URL using direct constructor', async () => {
     expect.assertions(1)


### PR DESCRIPTION
* remove integration tests that attempt to resolve did:web:did.actor:alice as the service is no longer operational

## What issue is this PR fixing

Example:
`fixes #1413`

## What is being changed
tests are simply commented out until a suitable replacement is found

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.

