### PR TITLE
fix(core-types): regenerate plugin schema

### DIFF
--- a/packages/core-types/src/plugin.schema.ts
+++ b/packages/core-types/src/plugin.schema.ts
@@ -4363,7 +4363,15 @@ export const schema = {
           "description": "The data type for `@context` properties of credentials, presentations, etc."
         },
         "DateType": {
-          "type": "string",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string",
+              "format": "date-time"
+            }
+          ],
           "description": "Represents an issuance or expiration date for Credentials / Presentations. This is used as input when creating them."
         },
         "CredentialStatusReference": {


### PR DESCRIPTION
## What issue is this PR fixing
* npm publish failing due to out of date `plugin.schema.ts` in `core-types` after recent dependency update

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [ ] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.

