### PR TITLE
fix(deps): bump ethr-did-resolver to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "did-jwt-vc": "4.0.4",
     "did-resolver": "4.1.0",
     "ethers": "6.11.1",
-    "ethr-did-resolver": "10.1.9",
+    "ethr-did-resolver": "11.0.2",
     "express": "4.19.2",
     "ganache": "7.9.2",
     "jest": "29.7.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -75,7 +75,7 @@
     "debug": "^4.3.4",
     "did-resolver": "^4.1.0",
     "dotenv": "^16.4.5",
-    "ethr-did-resolver": "^10.1.5",
+    "ethr-did-resolver": "^11.0.2",
     "express": "^4.18.2",
     "express-handlebars": "^7.1.2",
     "fuzzy": "^0.1.3",

--- a/packages/did-provider-ethr/package.json
+++ b/packages/did-provider-ethr/package.json
@@ -14,7 +14,7 @@
     "@veramo/did-manager": "workspace:^",
     "debug": "^4.3.3",
     "ethers": "^6.11.1",
-    "ethr-did": "^3.0.5"
+    "ethr-did": "^3.0.21"
   },
   "devDependencies": {
     "@types/debug": "4.1.8",

--- a/packages/did-resolver/package.json
+++ b/packages/did-resolver/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/debug": "4.1.8",
-    "ethr-did-resolver": "10.1.9",
+    "ethr-did-resolver": "11.0.2",
     "typescript": "5.3.3",
     "web-did-resolver": "2.0.27"
   },

--- a/packages/test-react-app/package.json
+++ b/packages/test-react-app/package.json
@@ -32,7 +32,7 @@
     "buffer": "npm:buffer",
     "crypto": "npm:crypto-browserify",
     "did-resolver": "^4.1.0",
-    "ethr-did-resolver": "^10.1.0",
+    "ethr-did-resolver": "^11.0.2",
     "path": "npm:path-browserify",
     "process": "npm:process",
     "react": "18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
         specifier: 6.11.1
         version: 6.11.1(bufferutil@4.0.7)(utf-8-validate@6.0.3)
       ethr-did-resolver:
-        specifier: 10.1.9
-        version: 10.1.9(bufferutil@4.0.7)(utf-8-validate@6.0.3)
+        specifier: 11.0.2
+        version: 11.0.2(bufferutil@4.0.7)(utf-8-validate@6.0.3)
       express:
         specifier: 4.19.2
         version: 4.19.2
@@ -119,7 +119,7 @@ importers:
         version: 23.0.2(typescript@5.3.3)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.23.6)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.6))(jest@29.7.0(@types/node@20.11.19)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.11.19)(typescript@5.3.3)))(typescript@5.3.3)
+        version: 29.1.2(@babel/core@7.22.9)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.22.9))(jest@29.7.0(@types/node@20.11.19)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.11.19)(typescript@5.3.3)))(typescript@5.3.3)
       ts-json-schema-generator:
         specifier: 1.5.0
         version: 1.5.0
@@ -271,8 +271,8 @@ importers:
         specifier: ^16.4.5
         version: 16.4.5
       ethr-did-resolver:
-        specifier: ^10.1.5
-        version: 10.1.5(bufferutil@4.0.7)(utf-8-validate@6.0.3)
+        specifier: ^11.0.2
+        version: 11.0.2(bufferutil@4.0.7)(utf-8-validate@6.0.3)
       express:
         specifier: ^4.18.2
         version: 4.18.2
@@ -589,7 +589,7 @@ importers:
     optionalDependencies:
       '@veramo/credential-ld':
         specifier: ^6.0.0
-        version: 6.0.0(bufferutil@4.0.7)(encoding@0.1.13)(utf-8-validate@5.0.7)
+        version: 6.0.0(bufferutil@4.0.7)(encoding@0.1.13)(expo@49.0.21(@babel/core@7.23.6)(bufferutil@4.0.7)(encoding@0.1.13)(utf-8-validate@5.0.7))(react-native@0.73.0(@babel/core@7.23.6)(@babel/preset-env@7.23.6(@babel/core@7.23.6))(bufferutil@4.0.7)(encoding@0.1.13)(react@18.2.0)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7)
     devDependencies:
       '@types/debug':
         specifier: 4.1.8
@@ -805,8 +805,8 @@ importers:
         specifier: ^6.11.1
         version: 6.11.1(bufferutil@4.0.7)(utf-8-validate@5.0.7)
       ethr-did:
-        specifier: ^3.0.5
-        version: 3.0.5(bufferutil@4.0.7)(utf-8-validate@5.0.7)
+        specifier: ^3.0.21
+        version: 3.0.21(bufferutil@4.0.7)(utf-8-validate@5.0.7)
     devDependencies:
       '@types/debug':
         specifier: 4.1.8
@@ -1044,8 +1044,8 @@ importers:
         specifier: 4.1.8
         version: 4.1.8
       ethr-did-resolver:
-        specifier: 10.1.9
-        version: 10.1.9(bufferutil@4.0.7)(utf-8-validate@6.0.3)
+        specifier: 11.0.2
+        version: 11.0.2(bufferutil@4.0.7)(utf-8-validate@6.0.3)
       typescript:
         specifier: 5.3.3
         version: 5.3.3
@@ -1443,8 +1443,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       ethr-did-resolver:
-        specifier: ^10.1.0
-        version: 10.1.0(bufferutil@4.0.7)(utf-8-validate@5.0.7)
+        specifier: ^11.0.2
+        version: 11.0.2(bufferutil@4.0.7)(utf-8-validate@5.0.7)
       path:
         specifier: npm:path-browserify
         version: path-browserify@1.0.1
@@ -3601,9 +3601,6 @@ packages:
 
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
-
-  '@noble/ciphers@0.3.0':
-    resolution: {integrity: sha512-ldbrnOjmNRwFdXcTM6uXDcxpMIFrbzAWNnpBPp4oTJTFF0XByGD6vf45WrehZGXRQTRVV+Zm8YP+EgEf+e4cWA==}
 
   '@noble/ciphers@0.4.1':
     resolution: {integrity: sha512-QCOA9cgf3Rc33owG0AYBB9wszz+Ul2kramWN8tXG44Gyciud/tbkEqvxRF/IpqQaBpRBNi9f4jdNxqB2CQCIXg==}
@@ -6637,9 +6634,6 @@ packages:
     resolution: {integrity: sha512-O/VSW+pux25+bERGQ1Z+LNv8z8gIy++yL8yjspxNZHCLjdmCelZz3hjuIpHlixhBCFP2YyTOQqGg8QeIMRwN9Q==}
     engines: {node: '>=18'}
 
-  did-jwt@7.4.2:
-    resolution: {integrity: sha512-bdMVrUKD8wBiYihrxm5Bso33vYuw5DHxxN6y+IFSpHQpYQF16nuW6T8+FCrVkS5gDYE6jFZmnkqjJwycT4K7AA==}
-
   did-jwt@8.0.0:
     resolution: {integrity: sha512-lJSVC9Ckxl+U+jDPbdATDtXV7CwE0XGT0Js6KNfjRlaj0LTXvDF90IAyayFwLUzO6punA/q3ZHVfTZaYDhHrLw==}
 
@@ -7120,17 +7114,14 @@ packages:
     resolution: {integrity: sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==}
     engines: {node: '>=6.5.0', npm: '>=3'}
 
-  ethr-did-resolver@10.1.0:
-    resolution: {integrity: sha512-PH3R8UQGpJGWXaVVSWPppPiEzb7eHrzG6yTCGtk23Fw8Et2totj+7V1id+zxCQvToM9cW+CHA/+k64F8xpk/Mw==}
-
   ethr-did-resolver@10.1.5:
     resolution: {integrity: sha512-wVCKhF6qQo2IewH9ui4lRBixbvT/A6szZFQoJkfvjP6EU/3MSb4KOP5QNpM37zmFU/rQGjHNt7bF13fNcmZ6wQ==}
 
-  ethr-did-resolver@10.1.9:
-    resolution: {integrity: sha512-rfX6RAHnw3kv00vx/g7B9jZNVvxRBr3/JBlNJAVyOKYALwlTo3aCb+G2/wGY6HFMPlmAzP7c/k58B+Tr1z0u1Q==}
+  ethr-did-resolver@11.0.2:
+    resolution: {integrity: sha512-xvJqOX0M23LjiDs3gusHMMHP9U0N0ZwBesmABzci5XzPJOk52MgCygfRx09PZLrVsoZVEjValmHJBle3vPrtmQ==}
 
-  ethr-did@3.0.5:
-    resolution: {integrity: sha512-qvA2nBqsxQF2YFPoQ7v0rgSVlj+9CCBnbAu6VtD/veJTq9dhytsEtjz6VDCIqJ6mqEMw7nb8sTLDSwHRgbwyiA==}
+  ethr-did@3.0.21:
+    resolution: {integrity: sha512-2ojxqkGlujuhwtN5bSqESekfkpleOO+Nd3nwMyJmU4nB0K1fKe9+psL11VEh4AJ29+Rol+3gS4f/GjTCe3SF/Q==}
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -17783,8 +17774,6 @@ snapshots:
     dependencies:
       eslint-scope: 5.1.1
 
-  '@noble/ciphers@0.3.0': {}
-
   '@noble/ciphers@0.4.1': {}
 
   '@noble/ciphers@0.5.3': {}
@@ -19563,7 +19552,7 @@ snapshots:
       - supports-color
     optional: true
 
-  '@veramo/credential-ld@6.0.0(bufferutil@4.0.7)(encoding@0.1.13)(utf-8-validate@5.0.7)':
+  '@veramo/credential-ld@6.0.0(bufferutil@4.0.7)(encoding@0.1.13)(expo@49.0.21(@babel/core@7.23.6)(bufferutil@4.0.7)(encoding@0.1.13)(utf-8-validate@5.0.7))(react-native@0.73.0(@babel/core@7.23.6)(@babel/preset-env@7.23.6(@babel/core@7.23.6))(bufferutil@4.0.7)(encoding@0.1.13)(react@18.2.0)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7)':
     dependencies:
       '@digitalcredentials/ed25519-signature-2020': 4.0.0(expo-crypto@12.8.1(expo@49.0.21(@babel/core@7.23.6)(bufferutil@4.0.7)(encoding@0.1.13)(utf-8-validate@5.0.7)))(expo@49.0.21(@babel/core@7.23.6)(bufferutil@4.0.7)(encoding@0.1.13)(utf-8-validate@5.0.7))(msrcrypto@1.5.8)(react-native-securerandom@1.0.1(react-native@0.73.0(@babel/core@7.23.6)(@babel/preset-env@7.23.6(@babel/core@7.23.6))(bufferutil@4.0.7)(encoding@0.1.13)(react@18.2.0)(utf-8-validate@5.0.7)))(react-native@0.73.0(@babel/core@7.23.6)(@babel/preset-env@7.23.6(@babel/core@7.23.6))(bufferutil@4.0.7)(encoding@0.1.13)(react@18.2.0)(utf-8-validate@5.0.7))(web-streams-polyfill@3.2.1)
       '@digitalcredentials/ed25519-verification-key-2020': 4.0.0
@@ -20148,20 +20137,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-jest@29.7.0(@babel/core@7.23.6):
-    dependencies:
-      '@babel/core': 7.23.6
-      '@jest/transform': 29.7.0
-      '@types/babel__core': 7.20.1
-      babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.6.3(@babel/core@7.23.6)
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   babel-loader@8.3.0(@babel/core@7.20.12)(webpack@5.75.0):
     dependencies:
       '@babel/core': 7.20.12
@@ -20437,13 +20412,6 @@ snapshots:
       '@babel/core': 7.22.9
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.22.9)
-
-  babel-preset-jest@29.6.3(@babel/core@7.23.6):
-    dependencies:
-      '@babel/core': 7.23.6
-      babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.23.6)
-    optional: true
 
   babel-preset-react-app@10.0.1:
     dependencies:
@@ -21772,17 +21740,6 @@ snapshots:
       did-jwt: 8.0.4
       did-resolver: 4.1.0
 
-  did-jwt@7.4.2:
-    dependencies:
-      '@noble/ciphers': 0.3.0
-      '@noble/curves': 1.4.2
-      '@noble/hashes': 1.4.0
-      '@scure/base': 1.1.3
-      canonicalize: 2.0.0
-      did-resolver: 4.1.0
-      multiformats: 12.0.1
-      uint8arrays: 4.0.6
-
   did-jwt@8.0.0:
     dependencies:
       '@noble/ciphers': 0.4.1
@@ -22384,7 +22341,7 @@ snapshots:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
 
-  ethr-did-resolver@10.1.0(bufferutil@4.0.7)(utf-8-validate@5.0.7):
+  ethr-did-resolver@10.1.5(bufferutil@4.0.7)(utf-8-validate@5.0.7):
     dependencies:
       did-resolver: 4.1.0
       ethers: 6.11.1(bufferutil@4.0.7)(utf-8-validate@5.0.7)
@@ -22392,28 +22349,28 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  ethr-did-resolver@10.1.5(bufferutil@4.0.7)(utf-8-validate@6.0.3):
+  ethr-did-resolver@11.0.2(bufferutil@4.0.7)(utf-8-validate@5.0.7):
     dependencies:
-      did-resolver: 4.1.0
-      ethers: 6.11.1(bufferutil@4.0.7)(utf-8-validate@6.0.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  ethr-did-resolver@10.1.9(bufferutil@4.0.7)(utf-8-validate@6.0.3):
-    dependencies:
-      did-resolver: 4.1.0
-      ethers: 6.11.1(bufferutil@4.0.7)(utf-8-validate@6.0.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  ethr-did@3.0.5(bufferutil@4.0.7)(utf-8-validate@5.0.7):
-    dependencies:
-      did-jwt: 7.4.2
       did-resolver: 4.1.0
       ethers: 6.11.1(bufferutil@4.0.7)(utf-8-validate@5.0.7)
-      ethr-did-resolver: 10.1.0(bufferutil@4.0.7)(utf-8-validate@5.0.7)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  ethr-did-resolver@11.0.2(bufferutil@4.0.7)(utf-8-validate@6.0.3):
+    dependencies:
+      did-resolver: 4.1.0
+      ethers: 6.11.1(bufferutil@4.0.7)(utf-8-validate@6.0.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  ethr-did@3.0.21(bufferutil@4.0.7)(utf-8-validate@5.0.7):
+    dependencies:
+      did-jwt: 8.0.4
+      did-resolver: 4.1.0
+      ethers: 6.11.1(bufferutil@4.0.7)(utf-8-validate@5.0.7)
+      ethr-did-resolver: 10.1.5(bufferutil@4.0.7)(utf-8-validate@5.0.7)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -29161,7 +29118,7 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.20.12)
 
-  ts-jest@29.1.2(@babel/core@7.23.6)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.6))(jest@29.7.0(@types/node@20.11.19)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.11.19)(typescript@5.3.3)))(typescript@5.3.3):
+  ts-jest@29.1.2(@babel/core@7.22.9)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.22.9))(jest@29.7.0(@types/node@20.11.19)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.11.19)(typescript@5.3.3)))(typescript@5.3.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -29174,9 +29131,9 @@ snapshots:
       typescript: 5.3.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.22.9
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.23.6)
+      babel-jest: 29.7.0(@babel/core@7.22.9)
 
   ts-json-schema-generator@1.5.0:
     dependencies:


### PR DESCRIPTION
## What issue is this PR fixing

ethr-did-resolver@<11.x package was causing some bundlers to fail in certain situations due to a missing default export.