### PR TITLE
feat: improve key creation/import options when creating identifiers

### DIFF
--- a/packages/did-provider-ethr/package.json
+++ b/packages/did-provider-ethr/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@veramo/core-types": "workspace:^",
     "@veramo/did-manager": "workspace:^",
+    "@veramo/utils": "workspace:^",
     "debug": "^4.3.3",
     "ethers": "^6.11.1",
     "ethr-did": "^3.0.21"

--- a/packages/did-provider-ethr/src/__tests__/ethr-did-provider.test.ts
+++ b/packages/did-provider-ethr/src/__tests__/ethr-did-provider.test.ts
@@ -65,6 +65,32 @@ describe('EthrDIDProvider', () => {
   })
 
   describe('adding keys', () => {
+    it('supports implicit creation of a Secp256k1 key', async () => {
+      const newDid = await agent.didManagerCreate({
+        kms: KMS,
+        provider: PROVIDER
+      })
+
+      expect(newDid.controllerKeyId).toBeDefined()
+    })
+
+    it('supports creation with a key reference', async () => {
+      const newKey = await agent.keyManagerCreate({
+        kms: KMS,
+        type: 'Secp256k1'
+      })
+
+      const newDid = await agent.didManagerCreate({
+        kms: KMS,
+        provider: PROVIDER,
+        options: {
+          keyRef: newKey.kid,
+        }
+      })
+
+      expect(newDid.controllerKeyId).toBe(newKey.kid)
+    })
+
     it('returns the signed addKey transaction parameters for an Ed25519 key type', async () => {
       expect.assertions(11)
       const ed25519Key: MinimalImportableKey = {

--- a/packages/did-provider-ethr/src/ethr-did-provider.ts
+++ b/packages/did-provider-ethr/src/ethr-did-provider.ts
@@ -1,4 +1,4 @@
-import { IAgentContext, IIdentifier, IKey, IKeyManager, IService } from '@veramo/core-types'
+import { IAgentContext, IIdentifier, IKey, IKeyManager, IService, KeyMetadata } from '@veramo/core-types'
 import { AbstractIdentifierProvider } from '@veramo/did-manager'
 import { Provider, SigningKey, computeAddress, JsonRpcProvider, TransactionRequest, Signature } from 'ethers'
 import { KmsEthereumSigner } from './kms-eth-signer.js'
@@ -40,6 +40,13 @@ export interface CreateDidEthrOptions {
    * network, if no `network` option is specified.
    */
   providerName?: string
+
+  /**
+   * Metadata passed to the KMS when creating the key
+   */
+  key?: {
+    meta?: KeyMetadata
+  }
 }
 
 export interface TransactionOptions extends TransactionRequest {
@@ -183,7 +190,11 @@ export class EthrDIDProvider extends AbstractIdentifierProvider {
     { kms, options }: { kms?: string; options?: CreateDidEthrOptions },
     context: IRequiredContext,
   ): Promise<Omit<IIdentifier, 'provider'>> {
-    const key = await context.agent.keyManagerCreate({ kms: kms || this.defaultKms, type: 'Secp256k1' })
+    const key = await context.agent.keyManagerCreate({
+      kms: kms || this.defaultKms,
+      type: 'Secp256k1',
+      meta: options?.key?.meta
+    })
     const compressedPublicKey = SigningKey.computePublicKey(`0x${key.publicKeyHex}`, true)
 
     let networkSpecifier

--- a/packages/did-provider-ethr/tsconfig.json
+++ b/packages/did-provider-ethr/tsconfig.json
@@ -12,6 +12,9 @@
     },
     {
       "path": "../did-manager"
+    },
+    {
+      "path": "../utils"
     }
   ]
 }

--- a/packages/did-provider-jwk/src/__tests__/jwk.test.ts
+++ b/packages/did-provider-jwk/src/__tests__/jwk.test.ts
@@ -34,6 +34,38 @@ describe('create did:jwk', () => {
   it('Secp256k1', async () => {
     const id = await agent.didManagerCreate({
       options: {
+        key: {
+          type: 'Secp256k1',
+          privateKeyHex: 'a5e81a8cd50cf5c31d5b87db3e153e2817f86de350a60edc2335f76d5c3b4e0d',
+        }
+      },
+    })
+    expect(id.did).toEqual(
+      'did:jwk:eyJhbGciOiJFUzI1NksiLCJjcnYiOiJzZWNwMjU2azEiLCJrdHkiOiJFQyIsInVzZSI6InNpZyIsIngiOiJVNV85NlJMQWxMeEl0a3llNXhzcnJzNGt4eEM4clN4N3JNN1dGZllLNVRrIiwieSI6IlNjM0pVM25yVUZWdEVjc0stckRscHNxTXRIWFVFN0x4SXdmTUxYOVVPTjQifQ',
+    )
+  })
+
+  it('Secp256k1 with keyRef', async () => {
+    const key = await agent.keyManagerImport({
+      kms: defaultKms,
+      type: 'Secp256k1',
+      privateKeyHex: 'a5e81a8cd50cf5c31d5b87db3e153e2817f86de350a60edc2335f76d5c3b4e0d',
+    })
+
+    const id = await agent.didManagerCreate({
+      options: {
+        keyRef: key.kid
+      },
+    })
+
+    expect(id.did).toEqual(
+      'did:jwk:eyJhbGciOiJFUzI1NksiLCJjcnYiOiJzZWNwMjU2azEiLCJrdHkiOiJFQyIsInVzZSI6InNpZyIsIngiOiJVNV85NlJMQWxMeEl0a3llNXhzcnJzNGt4eEM4clN4N3JNN1dGZllLNVRrIiwieSI6IlNjM0pVM25yVUZWdEVjc0stckRscHNxTXRIWFVFN0x4SXdmTUxYOVVPTjQifQ',
+    )
+  })
+
+  it('Secp256k1 deprecated config', async () => {
+    const id = await agent.didManagerCreate({
+      options: {
         keyType: 'Secp256k1',
         privateKeyHex: 'a5e81a8cd50cf5c31d5b87db3e153e2817f86de350a60edc2335f76d5c3b4e0d',
       },
@@ -44,6 +76,38 @@ describe('create did:jwk', () => {
   })
 
   it('Ed25519', async () => {
+    const id = await agent.didManagerCreate({
+      options: {
+        key: {
+          type: 'Ed25519',
+          privateKeyHex: 'a5e81a8cd50cf5c31d5b87db3e153e2817f86de350a60edc2335f76d5c3b4e0d',
+        }
+      },
+    })
+    expect(id.did).toEqual(
+      'did:jwk:eyJhbGciOiJFZERTQSIsImNydiI6IkVkMjU1MTkiLCJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJ4IjoiTTNodVJCZnJpU3lHemlJS3pUSE5nS1djSVhuX3IxUzYxRnZBcUQyVmhSUSJ9',
+    )
+  })
+
+  it('Ed25519 with keyRef', async () => {
+    const key = await agent.keyManagerImport({
+      kms: defaultKms,
+      type: 'Ed25519',
+      privateKeyHex: 'a5e81a8cd50cf5c31d5b87db3e153e2817f86de350a60edc2335f76d5c3b4e0d',
+    })
+
+    const id = await agent.didManagerCreate({
+      options: {
+        keyRef: key.kid
+      },
+    })
+
+    expect(id.did).toEqual(
+      'did:jwk:eyJhbGciOiJFZERTQSIsImNydiI6IkVkMjU1MTkiLCJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJ4IjoiTTNodVJCZnJpU3lHemlJS3pUSE5nS1djSVhuX3IxUzYxRnZBcUQyVmhSUSJ9',
+    )
+  })
+
+  it('Ed25519 deprecated config', async () => {
     const id = await agent.didManagerCreate({
       options: {
         keyType: 'Ed25519',
@@ -58,6 +122,38 @@ describe('create did:jwk', () => {
   it('X25519', async () => {
     const id = await agent.didManagerCreate({
       options: {
+        key: {
+          type: 'X25519',
+          privateKeyHex: 'a5e81a8cd50cf5c31d5b87db3e153e2817f86de350a60edc2335f76d5c3b4e0d',
+        }
+      },
+    })
+    expect(id.did).toEqual(
+      'did:jwk:eyJhbGciOiJFQ0RILUVTIiwiY3J2IjoiWDI1NTE5Iiwia3R5IjoiT0tQIiwidXNlIjoiZW5jIiwieCI6IlVuNFNEWk12R2dReENiZkRBOWpwNjlyNDdvVWdsSF93eU1aRjU2THAwbU0ifQ',
+    )
+  })
+
+  it('X25519 with keyRef', async () => {
+    const key = await agent.keyManagerImport({
+      kms: defaultKms,
+      type: 'X25519',
+      privateKeyHex: 'a5e81a8cd50cf5c31d5b87db3e153e2817f86de350a60edc2335f76d5c3b4e0d',
+    })
+
+    const id = await agent.didManagerCreate({
+      options: {
+        keyRef: key.kid
+      },
+    })
+
+    expect(id.did).toEqual(
+      'did:jwk:eyJhbGciOiJFQ0RILUVTIiwiY3J2IjoiWDI1NTE5Iiwia3R5IjoiT0tQIiwidXNlIjoiZW5jIiwieCI6IlVuNFNEWk12R2dReENiZkRBOWpwNjlyNDdvVWdsSF93eU1aRjU2THAwbU0ifQ',
+    )
+  })
+
+  it('X25519 deprecated config', async () => {
+    const id = await agent.didManagerCreate({
+      options: {
         keyType: 'X25519',
         privateKeyHex: 'a5e81a8cd50cf5c31d5b87db3e153e2817f86de350a60edc2335f76d5c3b4e0d',
       },
@@ -68,6 +164,38 @@ describe('create did:jwk', () => {
   })
 
   it('Secp256r1', async () => {
+    const id = await agent.didManagerCreate({
+      options: {
+        key: {
+          type: 'Secp256r1',
+          privateKeyHex: 'a5e81a8cd50cf5c31d5b87db3e153e2817f86de350a60edc2335f76d5c3b4e0d',
+        }
+      },
+    })
+    expect(id.did).toEqual(
+      'did:jwk:eyJhbGciOiJFUzI1NiIsImNydiI6IlAtMjU2Iiwia3R5IjoiRUMiLCJ1c2UiOiJzaWciLCJ4IjoiejhTTlNYTVgxUjZlVEt6SkdtLUE3ZWpBZkZsdURsaUhKdW9nT2FQc0REUSIsInkiOiJLUUtBTWVwTU56dHJseTB6ODI3MTg0dDRQdkFuU0lULW1MMFFsaUg1enU0In0',
+    )
+  })
+
+  it('Secp256r1 with keyRef', async () => {
+    const key = await agent.keyManagerImport({
+      kms: defaultKms,
+      type: 'Secp256r1',
+      privateKeyHex: 'a5e81a8cd50cf5c31d5b87db3e153e2817f86de350a60edc2335f76d5c3b4e0d',
+    })
+
+    const id = await agent.didManagerCreate({
+      options: {
+        keyRef: key.kid
+      },
+    })
+
+    expect(id.did).toEqual(
+      'did:jwk:eyJhbGciOiJFUzI1NiIsImNydiI6IlAtMjU2Iiwia3R5IjoiRUMiLCJ1c2UiOiJzaWciLCJ4IjoiejhTTlNYTVgxUjZlVEt6SkdtLUE3ZWpBZkZsdURsaUhKdW9nT2FQc0REUSIsInkiOiJLUUtBTWVwTU56dHJseTB6ODI3MTg0dDRQdkFuU0lULW1MMFFsaUg1enU0In0',
+    )
+  })
+
+  it('Secp256r1 deprecated config', async () => {
     const id = await agent.didManagerCreate({
       options: {
         keyType: 'Secp256r1',

--- a/packages/did-provider-jwk/src/jwk-did-provider.ts
+++ b/packages/did-provider-jwk/src/jwk-did-provider.ts
@@ -26,7 +26,7 @@ export class JwkDIDProvider extends AbstractIdentifierProvider {
     { kms, options }: { kms?: string; options?: JwkCreateIdentifierOptions },
     context: IContext,
   ): Promise<Omit<IIdentifier, 'provider'>> {
-    const keyType: JwkDidSupportedKeyTypes = options?.key?.type || options?.keyType || 'Ed25519'
+    const keyType: JwkDidSupportedKeyTypes = options?.key?.type || options?.keyType || 'Secp256k1'
     const privateKeyHex = options?.key?.privateKeyHex || options?.privateKeyHex
 
     const key = await this.importOrGenerateKey(

--- a/packages/did-provider-jwk/src/jwk-did-provider.ts
+++ b/packages/did-provider-jwk/src/jwk-did-provider.ts
@@ -26,13 +26,15 @@ export class JwkDIDProvider extends AbstractIdentifierProvider {
     { kms, options }: { kms?: string; options?: JwkCreateIdentifierOptions },
     context: IContext,
   ): Promise<Omit<IIdentifier, 'provider'>> {
-    const keyType: JwkDidSupportedKeyTypes = options?.keyType || 'Secp256k1'
+    const keyType: JwkDidSupportedKeyTypes = options?.key?.type || options?.keyType || 'Ed25519'
+    const privateKeyHex = options?.key?.privateKeyHex || options?.privateKeyHex
+
     const key = await this.importOrGenerateKey(
       {
         kms: kms || this.defaultKms,
         options: {
-          keyType,
-          ...(options?.privateKeyHex && { privateKeyHex: options.privateKeyHex }),
+          type: keyType,
+          ...(privateKeyHex && { privateKeyHex }),
         },
       },
       context,
@@ -108,13 +110,15 @@ export class JwkDIDProvider extends AbstractIdentifierProvider {
     if (args.options.privateKeyHex) {
       return context.agent.keyManagerImport({
         kms: args.kms || this.defaultKms,
-        type: args.options.keyType,
+        type: args.options.type,
         privateKeyHex: args.options.privateKeyHex,
+        meta: args.options.meta,
       })
     }
     return context.agent.keyManagerCreate({
       kms: args.kms || this.defaultKms,
-      type: args.options.keyType,
+      type: args.options.type,
+      meta: args.options.meta,
     })
   }
 }

--- a/packages/did-provider-jwk/src/jwk-did-provider.ts
+++ b/packages/did-provider-jwk/src/jwk-did-provider.ts
@@ -32,17 +32,17 @@ export class JwkDIDProvider extends AbstractIdentifierProvider {
     },
     context: IContext,
   ): Promise<Omit<IIdentifier, 'provider'>> {
-    const keyType: JwkDidSupportedKeyTypes = options?.key?.type || options?.keyType || 'Secp256k1'
+    let keyType: JwkDidSupportedKeyTypes = options?.key?.type || options?.keyType || 'Secp256k1'
     const privateKeyHex = options?.key?.privateKeyHex || options?.privateKeyHex
 
     let key: IKey
 
     if (options?.keyRef) {
       key = await context.agent.keyManagerGet({ kid: options.keyRef })
-
       if (!Object.keys(SupportedKeyTypes).includes(key.type)) {
         throw new Error(`not_supported: Key type ${key.type} is not supported`)
       }
+      keyType = key.type as JwkDidSupportedKeyTypes
     } else {
       key = await importOrCreateKey(
         {

--- a/packages/did-provider-jwk/src/types/jwk-provider-types.ts
+++ b/packages/did-provider-jwk/src/types/jwk-provider-types.ts
@@ -1,7 +1,7 @@
 import { RequireOnly, KeyMetadata } from '@veramo/core-types'
-import { JwkDidSupportedKeyTypes, KeyUse } from '@veramo/utils'
+import { JwkDidSupportedKeyTypes, KeyUse, CreateIdentifierBaseOptions } from '@veramo/utils'
 
-export type JwkCreateIdentifierOptions = {
+export type JwkCreateIdentifierOptions = CreateIdentifierBaseOptions<JwkDidSupportedKeyTypes> & {
   /**
    * @deprecated use key.type instead
    */
@@ -12,19 +12,5 @@ export type JwkCreateIdentifierOptions = {
    */
   privateKeyHex?: string
 
-  key?: {
-    type?: JwkDidSupportedKeyTypes
-    privateKeyHex?: string
-    meta?: KeyMetadata
-  }
-
   keyUse?: KeyUse
-}
-
-export type JwkDidImportOrGenerateKeyArgs = {
-  kms: string
-  options: RequireOnly<
-    RequireOnly<JwkCreateIdentifierOptions, 'key'>['key'],
-    'type'
-  >
-}
+};

--- a/packages/did-provider-jwk/src/types/jwk-provider-types.ts
+++ b/packages/did-provider-jwk/src/types/jwk-provider-types.ts
@@ -1,17 +1,30 @@
+import { RequireOnly, KeyMetadata } from '@veramo/core-types'
 import { JwkDidSupportedKeyTypes, KeyUse } from '@veramo/utils'
 
 export type JwkCreateIdentifierOptions = {
+  /**
+   * @deprecated use key.type instead
+   */
   keyType?: JwkDidSupportedKeyTypes
+
+  /**
+   * @deprecated use key.privateKeyHex instead
+   */
   privateKeyHex?: string
+
+  key?: {
+    type?: JwkDidSupportedKeyTypes
+    privateKeyHex?: string
+    meta?: KeyMetadata
+  }
+
   keyUse?: KeyUse
 }
 
 export type JwkDidImportOrGenerateKeyArgs = {
   kms: string
-  options: ImportOrGenerateKeyOpts
-}
-
-type ImportOrGenerateKeyOpts = {
-  keyType: JwkDidSupportedKeyTypes
-  privateKeyHex?: string
+  options: RequireOnly<
+    RequireOnly<JwkCreateIdentifierOptions, 'key'>['key'],
+    'type'
+  >
 }

--- a/packages/did-provider-key/__tests__/key-did-provider.test.ts
+++ b/packages/did-provider-key/__tests__/key-did-provider.test.ts
@@ -38,41 +38,169 @@ describe('@veramo/did-provider-key', () => {
   })
 
   it('should create identifier with Ed25519 key', async () => {
-    const did = await agent.didManagerCreate({ options: { keyType: 'Ed25519' } })
+    const did = await agent.didManagerCreate({
+      options: {
+        key: {
+          type: 'Ed25519',
+        }
+      }
+    })
     expect(did).toBeDefined()
     expect(did.did).toMatch(/^did:key:z6Mk.*/)
   })
 
   it('should create identifier with X25519 key', async () => {
-    const did = await agent.didManagerCreate({ options: { keyType: 'X25519' } })
+    const did = await agent.didManagerCreate({
+      options: {
+        key: {
+          type: 'X25519'
+        }
+      }
+    })
     expect(did).toBeDefined()
     expect(did.did).toMatch(/^did:key:z6LS.*/)
   })
 
   it('should create identifier with Secp256k1 key', async () => {
-    const did = await agent.didManagerCreate({ options: { keyType: 'Secp256k1' } })
+    const did = await agent.didManagerCreate({
+      options: {
+        key: {
+          type: 'Secp256k1'
+        }
+      }
+    })
     expect(did).toBeDefined()
     expect(did.did).toMatch(/^did:key:zQ3s.*/)
   })
 
+  it('should create identifier with Ed25519 key ref', async () => {
+    const privateKeyHex = '06eb9e64569203679b36f834a4d9725c989d32a7fb52c341eae3517b3aff8ee6'
+    const key = await agent.keyManagerImport({
+      kms: defaultKms,
+      type: 'Ed25519',
+      privateKeyHex
+    })
+    const did = await agent.didManagerCreate({
+      options: {
+        keyRef: key.kid
+      }
+    })
+    expect(did).toBeDefined()
+    expect(did.did).toMatch(/^did:key:z6Mkq3FR8bz4e3oDcbHhGAmfUUW7bdCtEL2vK2Fsw16Z99Vk$/)
+  })
+
+  it('should create identifier with X25519 key ref', async () => {
+    const privateKeyHex = '06eb9e64569203679b36f834a4d9725c989d32a7fb52c341eae3517b3aff8ee6'
+    const key = await agent.keyManagerImport({
+      kms: defaultKms,
+      type: 'X25519',
+      privateKeyHex
+    })
+    const did = await agent.didManagerCreate({
+      options: {
+        keyRef: key.kid
+      }
+    })
+    expect(did).toBeDefined()
+    expect(did.did).toMatch(/^did:key:z6LSk74Z9nwqCr3M6Y2JNFEz1aQUaG2Ehnvc8XGjuK9LzbkS$/)
+  })
+
+  it('should create identifier with Secp256k1 key ref', async () => {
+    const privateKeyHex = '06eb9e64569203679b36f834a4d9725c989d32a7fb52c341eae3517b3aff8ee6'
+    const key = await agent.keyManagerImport({
+      kms: defaultKms,
+      type: 'Secp256k1',
+      privateKeyHex
+    })
+    const did = await agent.didManagerCreate({
+      options: {
+        keyRef: key.kid
+      }
+    })
+    expect(did).toBeDefined()
+    expect(did.did).toMatch(/^did:key:zQ3shmh97kcXoAqLZLjjc86HB5YNPGBekgFq7W7LmpEwE5mov$/)
+  })
+
   it('should create identifier with Ed25519 key given a private key', async () => {
     const privateKeyHex = '06eb9e64569203679b36f834a4d9725c989d32a7fb52c341eae3517b3aff8ee6'
-    const did = await agent.didManagerCreate({ options: { keyType: 'Ed25519', privateKeyHex } })
+    const did = await agent.didManagerCreate({
+      options: {
+        key: {
+          type: 'Ed25519',
+          privateKeyHex
+        }
+      }
+    })
     expect(did).toBeDefined()
     expect(did.did).toMatch(/^did:key:z6Mkq3FR8bz4e3oDcbHhGAmfUUW7bdCtEL2vK2Fsw16Z99Vk$/)
   })
 
   it('should create identifier with X25519 key given a private key', async () => {
     const privateKeyHex = '06eb9e64569203679b36f834a4d9725c989d32a7fb52c341eae3517b3aff8ee6'
-    const did = await agent.didManagerCreate({ options: { keyType: 'X25519', privateKeyHex } })
+    const did = await agent.didManagerCreate({
+      options: {
+        key: {
+          type: 'X25519',
+          privateKeyHex
+        }
+      }
+    })
     expect(did).toBeDefined()
     expect(did.did).toMatch(/^did:key:z6LSk74Z9nwqCr3M6Y2JNFEz1aQUaG2Ehnvc8XGjuK9LzbkS$/)
   })
 
   it('should create identifier with Secp256k1 key given a private key', async () => {
     const privateKeyHex = '06eb9e64569203679b36f834a4d9725c989d32a7fb52c341eae3517b3aff8ee6'
-    const did = await agent.didManagerCreate({ options: { keyType: 'Secp256k1', privateKeyHex } })
+    const did = await agent.didManagerCreate({
+      options: {
+        key: {
+          type: 'Secp256k1',
+          privateKeyHex
+        }
+      }
+    })
     expect(did).toBeDefined()
     expect(did.did).toMatch(/^did:key:zQ3shmh97kcXoAqLZLjjc86HB5YNPGBekgFq7W7LmpEwE5mov$/)
+  })
+
+  describe('deprecated config format', () => {
+    it('should create identifier with Ed25519 key', async () => {
+      const did = await agent.didManagerCreate({ options: { keyType: 'Ed25519' } })
+      expect(did).toBeDefined()
+      expect(did.did).toMatch(/^did:key:z6Mk.*/)
+    })
+  
+    it('should create identifier with X25519 key', async () => {
+      const did = await agent.didManagerCreate({ options: { keyType: 'X25519' } })
+      expect(did).toBeDefined()
+      expect(did.did).toMatch(/^did:key:z6LS.*/)
+    })
+  
+    it('should create identifier with Secp256k1 key', async () => {
+      const did = await agent.didManagerCreate({ options: { keyType: 'Secp256k1' } })
+      expect(did).toBeDefined()
+      expect(did.did).toMatch(/^did:key:zQ3s.*/)
+    })
+  
+    it('should create identifier with Ed25519 key given a private key', async () => {
+      const privateKeyHex = '06eb9e64569203679b36f834a4d9725c989d32a7fb52c341eae3517b3aff8ee6'
+      const did = await agent.didManagerCreate({ options: { keyType: 'Ed25519', privateKeyHex } })
+      expect(did).toBeDefined()
+      expect(did.did).toMatch(/^did:key:z6Mkq3FR8bz4e3oDcbHhGAmfUUW7bdCtEL2vK2Fsw16Z99Vk$/)
+    })
+  
+    it('should create identifier with X25519 key given a private key', async () => {
+      const privateKeyHex = '06eb9e64569203679b36f834a4d9725c989d32a7fb52c341eae3517b3aff8ee6'
+      const did = await agent.didManagerCreate({ options: { keyType: 'X25519', privateKeyHex } })
+      expect(did).toBeDefined()
+      expect(did.did).toMatch(/^did:key:z6LSk74Z9nwqCr3M6Y2JNFEz1aQUaG2Ehnvc8XGjuK9LzbkS$/)
+    })
+  
+    it('should create identifier with Secp256k1 key given a private key', async () => {
+      const privateKeyHex = '06eb9e64569203679b36f834a4d9725c989d32a7fb52c341eae3517b3aff8ee6'
+      const did = await agent.didManagerCreate({ options: { keyType: 'Secp256k1', privateKeyHex } })
+      expect(did).toBeDefined()
+      expect(did.did).toMatch(/^did:key:zQ3shmh97kcXoAqLZLjjc86HB5YNPGBekgFq7W7LmpEwE5mov$/)
+    })
   })
 })

--- a/packages/did-provider-key/src/key-did-provider.ts
+++ b/packages/did-provider-key/src/key-did-provider.ts
@@ -43,7 +43,7 @@ export class KeyDIDProvider extends AbstractIdentifierProvider {
     { kms, options }: { kms?: string; options?: CreateKeyDidOptions },
     context: IContext,
   ): Promise<Omit<IIdentifier, 'provider'>> {
-    const keyType = (options?.key?.type && keyCodecs[options?.key.type] && options.key.type) || 
+    let keyType = (options?.key?.type && keyCodecs[options?.key.type] && options.key.type) || 
                     (options?.keyType && keyCodecs[options?.keyType] && options.keyType) ||
                     'Ed25519'
     const privateKeyHex = options?.key?.privateKeyHex || options?.privateKeyHex
@@ -52,10 +52,10 @@ export class KeyDIDProvider extends AbstractIdentifierProvider {
 
     if (options?.keyRef) {
       key = await context.agent.keyManagerGet({ kid: options.keyRef })
-
       if (!Object.keys(keyCodecs).includes(key.type)) {
         throw new Error(`not_supported: Key type ${key.type} is not supported`)
       }
+      keyType = key.type as keyof typeof keyCodecs
     } else {
       key = await importOrCreateKey(
         {

--- a/packages/did-provider-peer/src/peer-did-provider.ts
+++ b/packages/did-provider-peer/src/peer-did-provider.ts
@@ -72,6 +72,18 @@ export class PeerDIDProvider extends AbstractIdentifierProvider {
     let key: IKey
     let agreementKey: IKey | undefined
 
+    // Exit early so we don't create a key if we can't continue
+    if (![0, 2].includes(options.num_algo)) {
+      throw new Error(`'PeerDIDProvider num algo ${options.num_algo} not supported yet.'`)
+    }
+
+    if (options.agreementKeyRef) {
+      agreementKey = await context.agent.keyManagerGet({ kid: options.agreementKeyRef })
+      if (agreementKey.type !== 'Ed25519') {
+        throw new Error('not_supported: Key type must be Ed25519')
+      }
+    }
+
     if (options.keyRef) {
       key = await context.agent.keyManagerGet({ kid: options.keyRef })
       if (key.type !== 'Ed25519') {
@@ -88,13 +100,6 @@ export class PeerDIDProvider extends AbstractIdentifierProvider {
       }, context)
     }
 
-    if (options.agreementKeyRef) {
-      agreementKey = await context.agent.keyManagerGet({ kid: options.agreementKeyRef })
-      if (agreementKey.type !== 'Ed25519') {
-        throw new Error('not_supported: Key type must be Ed25519')
-      }
-    }
-
     switch (options.num_algo) {
       case 0: {
         const methodSpecificId = bytesToMultibase(hexToBytes(key.publicKeyHex), 'base58btc', 'ed25519-pub')
@@ -106,10 +111,6 @@ export class PeerDIDProvider extends AbstractIdentifierProvider {
         }
         debug('Created', identifier.did)
         return identifier
-      }
-
-      case 1: {
-        throw new Error(`'PeerDIDProvider num algo ${options.num_algo} not supported yet.'`)
       }
 
       case 2: {

--- a/packages/did-provider-peer/src/peer-did-provider.ts
+++ b/packages/did-provider-peer/src/peer-did-provider.ts
@@ -41,7 +41,7 @@ type CreatePeerDidOptions = CreateIdentifierBaseOptions<'Ed25519'> & {
   service?: IService
 
   agreementKeyRef?: string;
-  agreementKey?: ImportOrCreateKeyOptions<'Ed25519'>
+  agreementKey?: ImportOrCreateKeyOptions<'X25519'>
 }
 
 /**

--- a/packages/did-provider-peer/src/peer-did-provider.ts
+++ b/packages/did-provider-peer/src/peer-did-provider.ts
@@ -74,13 +74,13 @@ export class PeerDIDProvider extends AbstractIdentifierProvider {
 
     // Exit early so we don't create a key if we can't continue
     if (![0, 2].includes(options.num_algo)) {
-      throw new Error(`'PeerDIDProvider num algo ${options.num_algo} not supported yet.'`)
+      throw new Error(`not_supported: PeerDIDProvider num algo ${options.num_algo} not supported yet.`)
     }
 
     if (options.agreementKeyRef) {
       agreementKey = await context.agent.keyManagerGet({ kid: options.agreementKeyRef })
-      if (agreementKey.type !== 'Ed25519') {
-        throw new Error('not_supported: Key type must be Ed25519')
+      if (agreementKey.type !== 'X25519') {
+        throw new Error('not_supported: Key type must be X25519')
       }
     }
 
@@ -119,7 +119,7 @@ export class PeerDIDProvider extends AbstractIdentifierProvider {
             kms: kms || this.defaultKms,
             options: {
               ...(options?.agreementKey ?? {}),
-              type: 'Ed25519',
+              type: 'X25519',
               privateKeyHex: agreementPrivateKeyHex,
             }
           }, context)
@@ -150,7 +150,7 @@ export class PeerDIDProvider extends AbstractIdentifierProvider {
       }
 
       default:
-        throw new Error(`'PeerDIDProvider num algo ${options.num_algo} not supported yet.'`)
+        throw new Error(`'not_supported: PeerDIDProvider num algo ${options.num_algo} not supported yet.'`)
     }
   }
 

--- a/packages/did-provider-pkh/package.json
+++ b/packages/did-provider-pkh/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@veramo/core-types": "workspace:^",
     "@veramo/did-manager": "workspace:^",
+    "@veramo/utils": "workspace:^",
     "caip": "^1.1.0",
     "debug": "^4.3.3",
     "did-resolver": "^4.1.0",

--- a/packages/did-provider-pkh/tsconfig.json
+++ b/packages/did-provider-pkh/tsconfig.json
@@ -6,5 +6,9 @@
     "declarationDir": "build",
     "skipLibCheck": true
   },
-  "references": [{ "path": "../core-types" }, { "path": "../did-manager" }]
+  "references": [
+    { "path": "../core-types" },
+    { "path": "../did-manager" },
+    { "path": "../utils" }
+  ]
 }

--- a/packages/did-provider-web/package.json
+++ b/packages/did-provider-web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@veramo/core-types": "workspace:^",
     "@veramo/did-manager": "workspace:^",
+    "@veramo/utils": "workspace:^",
     "debug": "^4.3.3"
   },
   "devDependencies": {

--- a/packages/did-provider-web/src/web-did-provider.ts
+++ b/packages/did-provider-web/src/web-did-provider.ts
@@ -30,13 +30,14 @@ export class WebDIDProvider extends AbstractIdentifierProvider {
     { kms, alias, options }: { kms?: string; alias?: string; options: CreateWebDidOptions },
     context: IContext,
   ): Promise<Omit<IIdentifier, 'provider'>> {
-    const keyType = options?.key?.type || options?.keyType || 'Secp256k1'
+    let keyType = options?.key?.type || options?.keyType || 'Secp256k1'
     const privateKeyHex = options?.key?.privateKeyHex
 
     let key: IKey
 
     if (options?.keyRef) {
       key = await context.agent.keyManagerGet({ kid: options.keyRef })
+      keyType = key.type;
     } else {
       key = await importOrCreateKey(
         {

--- a/packages/did-provider-web/src/web-did-provider.ts
+++ b/packages/did-provider-web/src/web-did-provider.ts
@@ -1,10 +1,27 @@
-import { IIdentifier, IKey, IService, IAgentContext, IKeyManager } from '@veramo/core-types'
+import { RequireOnly, IIdentifier, IKey, IService, IAgentContext, IKeyManager, TKeyType, KeyMetadata } from '@veramo/core-types'
 import { AbstractIdentifierProvider } from '@veramo/did-manager'
 
 import Debug from 'debug'
 const debug = Debug('veramo:web-did:identifier-provider')
 
 type IContext = IAgentContext<IKeyManager>
+
+type CreateWebDidOptions = {
+  /**
+   * @deprecated use key.type instead
+   */
+  keyType?: TKeyType
+
+  /**
+   * Metadata passed to the KMS when creating the key
+   * Namespaced under key to align with other did provider formats
+   */
+  key?: {
+    type?: TKeyType
+    privateKeyHex?: string
+    meta?: KeyMetadata
+  }
+}
 
 /**
  * {@link @veramo/did-manager#DIDManager} identifier provider for `did:web` identifiers
@@ -19,11 +36,23 @@ export class WebDIDProvider extends AbstractIdentifierProvider {
   }
 
   async createIdentifier(
-    { kms, alias, options }: { kms?: string; alias?: string; options: any },
+    { kms, alias, options }: { kms?: string; alias?: string; options: CreateWebDidOptions },
     context: IContext,
   ): Promise<Omit<IIdentifier, 'provider'>> {
-    const keyType = options?.keyType || 'Secp256k1'
-    const key = await context.agent.keyManagerCreate({ kms: kms || this.defaultKms, type: keyType })
+    const keyType = options?.key?.type || options?.keyType || 'Secp256k1'
+    const privateKeyHex = options?.key?.privateKeyHex
+
+    const key = await this.importOrGenerateKey(
+      {
+        kms: kms || this.defaultKms,
+        options: {
+          type: keyType,
+          ...(privateKeyHex && { privateKeyHex }),
+          ...(options?.key?.meta && { meta: options.key.meta }),
+        },
+      },
+      context,
+    )
 
     const identifier: Omit<IIdentifier, 'provider'> = {
       did: 'did:web:' + alias,
@@ -72,5 +101,30 @@ export class WebDIDProvider extends AbstractIdentifierProvider {
     context: IContext,
   ): Promise<any> {
     return { success: true }
+  }
+
+  private async importOrGenerateKey(
+    args: {
+      kms: string
+      options: RequireOnly<
+        RequireOnly<CreateWebDidOptions, 'key'>['key'],
+        'type'
+      >
+    },
+    context: IContext,
+  ): Promise<IKey> {
+    if (args.options.privateKeyHex) {
+      return context.agent.keyManagerImport({
+        kms: args.kms || this.defaultKms,
+        type: args.options.type,
+        privateKeyHex: args.options.privateKeyHex,
+        meta: args.options.meta,
+      })
+    }
+    return context.agent.keyManagerCreate({
+      kms: args.kms || this.defaultKms,
+      type: args.options.type,
+      meta: args.options.meta,
+    })
   }
 }

--- a/packages/did-provider-web/src/web-did-provider.ts
+++ b/packages/did-provider-web/src/web-did-provider.ts
@@ -1,26 +1,17 @@
-import { RequireOnly, IIdentifier, IKey, IService, IAgentContext, IKeyManager, TKeyType, KeyMetadata } from '@veramo/core-types'
+import { IIdentifier, IKey, IService, IAgentContext, IKeyManager, TKeyType } from '@veramo/core-types'
 import { AbstractIdentifierProvider } from '@veramo/did-manager'
+import { importOrCreateKey, CreateIdentifierBaseOptions } from '@veramo/utils'
 
 import Debug from 'debug'
 const debug = Debug('veramo:web-did:identifier-provider')
 
 type IContext = IAgentContext<IKeyManager>
 
-type CreateWebDidOptions = {
+type CreateWebDidOptions = CreateIdentifierBaseOptions & {
   /**
    * @deprecated use key.type instead
    */
   keyType?: TKeyType
-
-  /**
-   * Metadata passed to the KMS when creating the key
-   * Namespaced under key to align with other did provider formats
-   */
-  key?: {
-    type?: TKeyType
-    privateKeyHex?: string
-    meta?: KeyMetadata
-  }
 }
 
 /**
@@ -42,17 +33,23 @@ export class WebDIDProvider extends AbstractIdentifierProvider {
     const keyType = options?.key?.type || options?.keyType || 'Secp256k1'
     const privateKeyHex = options?.key?.privateKeyHex
 
-    const key = await this.importOrGenerateKey(
-      {
-        kms: kms || this.defaultKms,
-        options: {
-          type: keyType,
-          ...(privateKeyHex && { privateKeyHex }),
-          ...(options?.key?.meta && { meta: options.key.meta }),
+    let key: IKey
+
+    if (options?.keyRef) {
+      key = await context.agent.keyManagerGet({ kid: options.keyRef })
+    } else {
+      key = await importOrCreateKey(
+        {
+          kms: kms || this.defaultKms,
+          options: {
+            ...(options?.key ?? {}),
+            type: keyType,
+            privateKeyHex,
+          },
         },
-      },
-      context,
-    )
+        context,
+      )
+    }
 
     const identifier: Omit<IIdentifier, 'provider'> = {
       did: 'did:web:' + alias,
@@ -101,30 +98,5 @@ export class WebDIDProvider extends AbstractIdentifierProvider {
     context: IContext,
   ): Promise<any> {
     return { success: true }
-  }
-
-  private async importOrGenerateKey(
-    args: {
-      kms: string
-      options: RequireOnly<
-        RequireOnly<CreateWebDidOptions, 'key'>['key'],
-        'type'
-      >
-    },
-    context: IContext,
-  ): Promise<IKey> {
-    if (args.options.privateKeyHex) {
-      return context.agent.keyManagerImport({
-        kms: args.kms || this.defaultKms,
-        type: args.options.type,
-        privateKeyHex: args.options.privateKeyHex,
-        meta: args.options.meta,
-      })
-    }
-    return context.agent.keyManagerCreate({
-      kms: args.kms || this.defaultKms,
-      type: args.options.type,
-      meta: args.options.meta,
-    })
   }
 }

--- a/packages/did-provider-web/tsconfig.json
+++ b/packages/did-provider-web/tsconfig.json
@@ -5,5 +5,9 @@
     "outDir": "build",
     "declarationDir": "build"
   },
-  "references": [{ "path": "../core-types" }, { "path": "../did-manager" }]
+  "references": [
+    { "path": "../core-types" },
+    { "path": "../did-manager" },
+    { "path": "../utils" }
+  ]
 }

--- a/packages/utils/src/did-utils.ts
+++ b/packages/utils/src/did-utils.ts
@@ -1,11 +1,12 @@
 import { computeAddress, SigningKey } from 'ethers'
-import { DIDDocumentSection, IAgentContext, IIdentifier, IKey, IResolver } from '@veramo/core-types'
+import { DIDDocumentSection, IAgentContext, IIdentifier, IKey, IKeyManager, IResolver, KeyMetadata, IKeyManagerCreateArgs, MinimalImportableKey, RequireOnly, TKeyType } from '@veramo/core-types'
 import { DIDDocument, DIDResolutionOptions, VerificationMethod } from 'did-resolver'
 import { extractPublicKeyBytes } from 'did-jwt'
 import {
   _ExtendedIKey,
   _ExtendedVerificationMethod,
   _NormalizedVerificationMethod,
+  SupportedKeyTypes,
 } from './types/utility-types.js'
 import { isDefined } from './type-utils.js'
 import Debug from 'debug'
@@ -368,4 +369,28 @@ export function pickSigningKey(identifier: IIdentifier, keyRef?: string): IKey {
   }
 
   return key as IKey
+}
+
+type AvailableKeyOptions<K extends TKeyType> = Omit<Partial<IKeyManagerCreateArgs & MinimalImportableKey>, 'kms'> & {
+  type: K
+}
+
+export async function importOrCreateKey<K extends TKeyType = TKeyType>(
+  args: {
+    kms: string,
+    options: AvailableKeyOptions<K>
+  },
+  context: IAgentContext<IKeyManager>,
+) {
+  if (args.options.privateKeyHex) {
+    return context.agent.keyManagerImport({
+      ...args.options,
+      kms: args.kms,
+      privateKeyHex: args.options.privateKeyHex,
+    })
+  }
+  return context.agent.keyManagerCreate({
+    ...args.options,
+    kms: args.kms,
+  })
 }

--- a/packages/utils/src/did-utils.ts
+++ b/packages/utils/src/did-utils.ts
@@ -6,7 +6,7 @@ import {
   _ExtendedIKey,
   _ExtendedVerificationMethod,
   _NormalizedVerificationMethod,
-  SupportedKeyTypes,
+  ImportOrCreateKeyOptions,
 } from './types/utility-types.js'
 import { isDefined } from './type-utils.js'
 import Debug from 'debug'
@@ -371,14 +371,10 @@ export function pickSigningKey(identifier: IIdentifier, keyRef?: string): IKey {
   return key as IKey
 }
 
-type AvailableKeyOptions<K extends TKeyType> = Omit<Partial<IKeyManagerCreateArgs & MinimalImportableKey>, 'kms'> & {
-  type: K
-}
-
 export async function importOrCreateKey<K extends TKeyType = TKeyType>(
   args: {
     kms: string,
-    options: AvailableKeyOptions<K>
+    options: ImportOrCreateKeyOptions<K>
   },
   context: IAgentContext<IKeyManager>,
 ) {

--- a/packages/utils/src/types/utility-types.ts
+++ b/packages/utils/src/types/utility-types.ts
@@ -1,4 +1,5 @@
-import { IKey, KeyMetadata } from '@veramo/core-types'
+import { IKey, KeyMetadata, TKeyType, IKeyManagerCreateArgs, MinimalImportableKey, RequireOnly } from '@veramo/core-types'
+
 import { VerificationMethod } from 'did-resolver'
 
 /**
@@ -56,3 +57,13 @@ export enum SupportedKeyTypes {
 export type KeyUse = 'sig' | 'enc'
 
 export type JwkDidSupportedKeyTypes = keyof typeof SupportedKeyTypes
+
+export type ImportOrCreateKeyOptions<TKey extends TKeyType = TKeyType> = Omit<
+  IKeyManagerCreateArgs & MinimalImportableKey,
+  'kms' | 'type'
+> & { type: TKey }
+
+export type CreateIdentifierBaseOptions<T extends TKeyType = TKeyType> = {
+  keyRef?: string;
+  key?: ImportOrCreateKeyOptions<T>;
+}

--- a/packages/utils/src/types/utility-types.ts
+++ b/packages/utils/src/types/utility-types.ts
@@ -59,8 +59,8 @@ export type KeyUse = 'sig' | 'enc'
 export type JwkDidSupportedKeyTypes = keyof typeof SupportedKeyTypes
 
 export type ImportOrCreateKeyOptions<TKey extends TKeyType = TKeyType> = Omit<
-  IKeyManagerCreateArgs & MinimalImportableKey,
-  'kms' | 'type'
+  Partial<IKeyManagerCreateArgs & MinimalImportableKey>,
+  'kms'
 > & { type: TKey }
 
 export type CreateIdentifierBaseOptions<T extends TKeyType = TKeyType> = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -798,6 +798,9 @@ importers:
       '@veramo/did-manager':
         specifier: workspace:^
         version: link:../did-manager
+      '@veramo/utils':
+        specifier: workspace:^
+        version: link:../utils
       debug:
         specifier: ^4.3.3
         version: 4.3.4
@@ -983,6 +986,9 @@ importers:
       '@veramo/did-manager':
         specifier: workspace:^
         version: link:../did-manager
+      '@veramo/utils':
+        specifier: workspace:^
+        version: link:../utils
       caip:
         specifier: ^1.1.0
         version: 1.1.0
@@ -1011,6 +1017,9 @@ importers:
       '@veramo/did-manager':
         specifier: workspace:^
         version: link:../did-manager
+      '@veramo/utils':
+        specifier: workspace:^
+        version: link:../utils
       debug:
         specifier: ^4.3.3
         version: 4.3.4
@@ -4949,6 +4958,7 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version is no longer supported, please update to at least 0.8.*
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -7226,6 +7236,7 @@ packages:
 
   expo-random@13.4.0:
     resolution: {integrity: sha512-Z/Bbd+1MbkK8/4ukspgA3oMlcu0q3YTCu//7q2xHwy35huN6WCv4/Uw2OGyCiOQjAbU02zwq6swA+VgVmJRCEw==}
+    deprecated: This package is now deprecated in favor of expo-crypto, which provides the same functionality. To migrate, replace all imports from expo-random with imports from expo-crypto.
     peerDependencies:
       expo: '*'
 


### PR DESCRIPTION
## What issue is this PR fixing

At the moment, specifying key options when creating identifiers (via `didManagerCreate`) is fragile. Each provider has a slightly different format for `options`, and many omit the ability to provide `meta` for keys. This is a problem, as it means there is no nice way to create both an identifier and associated keys if you need to store metadata.

This PR proposes some non-breaking changes to each of the DID providers that unifies key option signature with a base type. It passes all key options from `options.key` to `keyManagerCreate/keyManagerImport` automatically.

If no `options.key` or `options.keyRef` is provided, each provider falls back to the currently support configuration signature, which has been deprecated.

## What is being changed

`createIdentifier` methods on each DID provider now utilise a base options type which includes a `keyRef` option, allowing the user to pass in an existing key, or a `key` option specifying the details for the key to be created/imported.

```
export type ImportOrCreateKeyOptions<TKey extends TKeyType = TKeyType> = Omit<
  IKeyManagerCreateArgs & MinimalImportableKey,
  'kms' | 'type'
> & { type: TKey }

export type CreateIdentifierBaseOptions<T extends TKeyType = TKeyType> = {
  keyRef?: string;
  key?: ImportOrCreateKeyOptions<T>;
}
```

For `did:peer`, there is an additional `agreementKey` and `agreementKeyRef` option.

Providers

- did-provider-ethr
- did-provider-jwk
- did-provider-key
- did-provider-peer
- did-provider-pkh
- did-provider-web

This change **does not** affect `did-provider-ion`. The ION provider requires specific metadata in each of the keys, which requires some consideration on the best way to handle. 

```
// Create with an existing key
agent.didManagerCreate({
  kms: 'local'.
  provider: 'did:peer',
  options: {
    keyRef: existingKey.kid
  }
})

// Create a new key with params
agent.didManagerCreate({
  kms: 'local'.
  provider: 'did:key',
  options: {
    key: {
      type: 'X25519',
      meta: { userId: 123 }
    }
  }
})

// Import a key
agent.didManagerCreate({
  kms: 'local'.
  provider: 'did:key',
  options: {
    key: {
      type: 'X25519',
      privateKeyHex: 'DEADBEEF',
      meta: { userId: 123 }
    }
  }
})
```

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [X] I added unit tests.
* [ ] I added integration tests.