### PR TITLE
feat(key-manager): allow user defined kid on keyManagerCreate

### DIFF
--- a/packages/core-types/src/plugin.schema.ts
+++ b/packages/core-types/src/plugin.schema.ts
@@ -540,6 +540,10 @@ export const schema = {
             "meta": {
               "$ref": "#/components/schemas/KeyMetadata",
               "description": "Optional. Key meta data"
+            },
+            "kid": {
+              "type": "string",
+              "description": "Key ID"
             }
           },
           "required": [

--- a/packages/core-types/src/types/IKeyManager.ts
+++ b/packages/core-types/src/types/IKeyManager.ts
@@ -42,6 +42,11 @@ export interface IKeyManagerCreateArgs {
    * Optional. Key meta data
    */
   meta?: KeyMetadata
+
+  /**
+   * Optional. Key ID
+   */
+  kid?: string;
 }
 
 /**

--- a/packages/key-manager/src/key-manager.ts
+++ b/packages/key-manager/src/key-manager.ts
@@ -87,7 +87,11 @@ export class KeyManager implements IAgentPlugin {
   async keyManagerCreate(args: IKeyManagerCreateArgs): Promise<ManagedKeyInfo> {
     const kms = this.getKms(args.kms)
     const partialKey = await kms.createKey({ type: args.type, meta: args.meta })
-    const key: IKey = { ...partialKey, kms: args.kms }
+    const key: IKey = {
+      ...partialKey,
+      kms: args.kms,
+      kid: args.kid ?? partialKey.kid
+    }
     if (args.meta || key.meta) {
       key.meta = { ...args.meta, ...key.meta }
     }


### PR DESCRIPTION
## What issue is this PR fixing

Closes #1353

## What is being changed
Add support for a user defined `kid` on `keyManagerCreate`

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because key manager does not currently have *any* tests, and I am aware that a PR without tests will likely get rejected.
