### PR TITLE
fix(credential-status): plugin class missing OpenAPI schema

### DIFF
--- a/packages/credential-status/src/credential-status.ts
+++ b/packages/credential-status/src/credential-status.ts
@@ -5,6 +5,7 @@ import {
   ICheckCredentialStatusArgs,
   ICredentialStatusVerifier,
   IResolver,
+  schema,
 } from '@veramo/core-types'
 import { extractIssuer, isDefined, resolveDidOrThrow } from '@veramo/utils'
 import { Status, StatusMethod } from 'credential-status'
@@ -29,6 +30,7 @@ import { Status, StatusMethod } from 'credential-status'
  */
 export class CredentialStatusPlugin implements IAgentPlugin {
   private readonly status: Status
+  readonly schema = schema.ICredentialStatusVerifier
   readonly methods: ICredentialStatusVerifier
 
   constructor(registry: Record<string, StatusMethod> = {}) {


### PR DESCRIPTION
## What issue is this PR fixing

`credential-status` plugin is missing a schema definition, causing it to crash the OpenAPI schema generator in `@veramo/remote-client`, so fails with remote agents.

## What is being changed
Added schema

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.
