### PR TITLE
perf: remove unused didManagerGet in createVerifiablePresentation

### DIFF
--- a/packages/credential-w3c/src/action-handler.ts
+++ b/packages/credential-w3c/src/action-handler.ts
@@ -210,16 +210,6 @@ export class CredentialPlugin implements IAgentPlugin {
       })
     }
 
-    const holder = removeDIDParameters(presentation.holder)
-
-    let identifier: IIdentifier
-    try {
-      identifier = await context.agent.didManagerGet({ did: holder })
-    } catch (e) {
-      throw new Error('invalid_argument: presentation.holder must be a DID managed by this agent')
-    }
-    const key = pickSigningKey(identifier, keyRef)
-
     let verifiablePresentation: VerifiablePresentation | undefined
 
     async function getPresentation(issuers: AbstractCredentialProvider[]) {


### PR DESCRIPTION
## What issue is this PR fixing

Based on a discussion on Discord, this PR removes an obsolete "didManagerGet" in the credential-w3c plugin within the createVerifiablePresentation function, because the specific code is additionally checked in the specific credential plugin which is called afterwards. This reduces the SQL query amount of the function.

## What is being changed
Remove the unused code in the action-handler of the credential-w3c plugin.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because no new logic was added, and I am aware that a PR without tests will likely get rejected.

