### PR TITLE
feat(did-manager): add 'isLocal' in 'options' to only modify DIDStore

### DIFF
--- a/__tests__/shared/didManager.ts
+++ b/__tests__/shared/didManager.ts
@@ -1,6 +1,6 @@
 // noinspection ES6PreferShortImport
 
-import { IDIDManager, IIdentifier, IKeyManager, TAgent } from '../../packages/core-types/src'
+import { IDIDManager, IIdentifier, IKeyManager, ManagedKeyInfo, TAgent } from '../../packages/core-types/src'
 
 type ConfiguredAgent = TAgent<IDIDManager & IKeyManager>
 
@@ -465,5 +465,112 @@ export default (testContext: {
         /illegal_argument: Identifier with alias:.*already exists.*but was created with a different provider.*/,
       )
     })
+
+    it('should add key only in DIDStore', async () => {
+      const webIdentifier = await agent.didManagerGetOrCreate({
+        alias: 'did.example.com',
+        provider: 'did:web',
+      })
+
+      const mockNewKey: ManagedKeyInfo = {
+        "type": "X25519",
+        "kid": "ec38b35a3cdf99d2aac3beecebe70e1451869a69d02cba923d0eed1f3969065e",
+        "publicKeyHex": "ec38b35a3cdf99d2aac3beecebe70e1451869a69d02cba923d0eed1f3969065e",
+        "meta": {
+          "algorithms": [
+            "ECDH",
+            "ECDH-ES",
+            "ECDH-1PU"
+          ]
+        },
+        "kms": "local"
+      }
+
+      const result = await agent.didManagerAddKey({
+        did: webIdentifier.did,
+        key: mockNewKey,
+        options: { isLocal: true },
+      })
+
+      expect(result).toEqual(true)
+
+      const updatedIdentifier = await agent.didManagerGet({ did: webIdentifier.did })
+      expect(updatedIdentifier.keys.some((key: any) => key.kid === mockNewKey.kid)).toBe(true)
+    })
+
+    it('should remove key from DIDStore', async () => {
+      const webIdentifier = await agent.didManagerGet({
+        did: 'did:web:did.example.com',
+      })
+
+      const mockNewKey: ManagedKeyInfo = {
+        "type": "X25519",
+        "kid": "ec38b35a3cdf99d2aac3beecebe70e1451869a69d02cba923d0eed1f3969065e",
+        "publicKeyHex": "ec38b35a3cdf99d2aac3beecebe70e1451869a69d02cba923d0eed1f3969065e",
+        "meta": {
+          "algorithms": [
+            "ECDH",
+            "ECDH-ES",
+            "ECDH-1PU"
+          ]
+        },
+        "kms": "local"
+      }
+
+      const result = await agent.didManagerRemoveKey({
+        did: webIdentifier.did,
+        kid:  mockNewKey.kid,
+        options: { isLocal: true },
+      })
+
+      expect(result).toEqual(true)
+
+      const updatedIdentifier = await agent.didManagerGet({ did: webIdentifier.did })
+      expect(updatedIdentifier.keys.some((key: any) => key.kid === mockNewKey.kid)).toBe(false)
+    })
+
+    it('should add service only in DIDStore', async () => {
+      const webIdentifier = await agent.didManagerGet({
+        did: 'did:web:did.example.com',
+      })
+
+      const mockService = {
+        id: 'did.example.com#didcomm_service',
+        type: 'Messaging',
+        serviceEndpoint: 'https://did.example.com/messaging',
+        description: 'Handles incoming messages',
+      }
+
+      const result = await agent.didManagerAddService({
+        did: webIdentifier.did,
+        service: mockService,
+        options: { isLocal: true },
+      });
+
+      expect(result).toEqual(true);
+
+      const updatedIdentifier = await agent.didManagerGet({ did: webIdentifier.did });
+      expect(updatedIdentifier.services.some((service: any) => service.id === mockService.id)).toBe(true)
+    });
+
+    it('should remove service from identifier with isLocal=true', async () => {
+      const webIdentifier = await agent.didManagerGet({
+        did: 'did:web:did.example.com',
+      });
+      const mockService = {
+        id: 'did.example.com#didcomm_service',
+      }
+
+      const result = await agent.didManagerRemoveService({
+        did: webIdentifier.did,
+        id: mockService.id,
+        options: { isLocal: true },
+      });
+
+      expect(result).toEqual(true);
+
+      const updatedIdentifier = await agent.didManagerGet({ did: webIdentifier.did });
+      expect(updatedIdentifier.services.some((service: any) => service.id === mockService.id)).toBe(false)
+    });
   })
 }

--- a/packages/did-manager/src/id-manager.ts
+++ b/packages/did-manager/src/id-manager.ts
@@ -223,7 +223,10 @@ export class DIDManager implements IAgentPlugin {
   ): Promise<any> {
     const identifier = await this.store.getDID({ did })
     const provider = this.getProvider(identifier.provider)
-    const result = await provider.addKey({ identifier, key, options }, context)
+    let result = true
+    if(!options.isLocal){
+      result = await provider.addKey({ identifier, key, options }, context)
+    }
     identifier.keys.push(key)
     await this.store.importDID(identifier)
     return result
@@ -236,7 +239,10 @@ export class DIDManager implements IAgentPlugin {
   ): Promise<any> {
     const identifier = await this.store.getDID({ did })
     const provider = this.getProvider(identifier.provider)
-    const result = await provider.removeKey({ identifier, kid, options }, context)
+    let result = true
+    if(!options.isLocal){
+      result = await provider.removeKey({ identifier, kid, options }, context)
+    }
     identifier.keys = identifier.keys.filter((k) => k.kid !== kid)
     await this.store.importDID(identifier)
     return result
@@ -249,7 +255,10 @@ export class DIDManager implements IAgentPlugin {
   ): Promise<any> {
     const identifier = await this.store.getDID({ did })
     const provider = this.getProvider(identifier.provider)
-    const result = await provider.addService({ identifier, service, options }, context)
+    let result = true
+    if(!options.isLocal){
+      result = await provider.addService({ identifier, service, options }, context)
+    }
     identifier.services.push(service)
     await this.store.importDID(identifier)
     return result
@@ -262,7 +271,10 @@ export class DIDManager implements IAgentPlugin {
   ): Promise<any> {
     const identifier = await this.store.getDID({ did })
     const provider = this.getProvider(identifier.provider)
-    const result = await provider.removeService({ identifier, id, options }, context)
+    let result = true
+    if(!options.isLocal){
+      result = await provider.removeService({ identifier, id, options }, context)
+    }
     identifier.services = identifier.services.filter((s) => s.id !== id)
     await this.store.importDID(identifier)
     return result


### PR DESCRIPTION
## What is being changed

I've added `isLocal` to allow only modifying DIDStore locally for the next methods, this allows modifying DIDStore without calling any DID provider.

- didManagerAddKey
- didManagerRemoveKey
- didManagerAddService
- didManagerRemoveService 

## Motivations

I have a use case where an Agent gives access to the DID to another Agent so that this one can also manage the DID. Actually doing that is only possible if I modify the database directly so the change I make allows the process to be done by the same methods.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [ ] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [X] I added integration tests.
