### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -1,5 +1,8 @@
 name: build-test-on-pr-cached
 on: [pull_request, workflow_dispatch]
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/decentralized-identity/veramo/security/code-scanning/1](https://github.com/decentralized-identity/veramo/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are necessary:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for interacting with pull requests (if applicable).
- Additional permissions can be added if specific steps require them.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden by job-specific `permissions` blocks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
