### PR TITLE
fix(remote-server): Limit information exposure through a stack trace

### DIFF
--- a/packages/remote-server/src/web-did-doc-router.ts
+++ b/packages/remote-server/src/web-did-doc-router.ts
@@ -122,7 +122,8 @@ export const WebDidDocRouter = (options: WebDidDocRouterOptions): Router => {
         const didDoc = didDocForIdentifier(serverIdentifier)
         res.json(didDoc)
       } catch (e) {
-        res.status(404).send(e)
+        console.error('Error resolving did:web:', e)
+        res.status(404).send('Unable to resolve DID document')
       }
     }
   })
@@ -136,7 +137,8 @@ export const WebDidDocRouter = (options: WebDidDocRouterOptions): Router => {
         const didDoc = didDocForIdentifier(identifier)
         res.json(didDoc)
       } catch (e) {
-        res.status(404).send(e)
+        console.error('Error resolving did:web:', e)
+        res.status(404).send('Unable to resolve DID document')
       }
     }
   })


### PR DESCRIPTION
Potential fix for [https://github.com/decentralized-identity/veramo/security/code-scanning/17](https://github.com/decentralized-identity/veramo/security/code-scanning/17)

The best fix is to replace `res.status(404).send(e)` and similar lines with a generic error message for the user, while logging the detailed error server-side for diagnostics. This should be done in both `catch` blocks for router handlers. Specifically, for both lines 125 and 139, update so that only a generic message is sent, and ensure that details are logged via `console.error`. The necessary changes are only to the affected `catch` blocks in packages/remote-server/src/web-did-doc-router.ts and do not require external imports or definition changes, as logging can be done with `console.error`, a standard global.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
