### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-test-publish-on-push.yml
+++ b/.github/workflows/build-test-publish-on-push.yml
@@ -1,4 +1,6 @@
 name: build-test-publish-on-push-cached
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   push:
@@ -145,6 +147,8 @@ jobs:
       - run: pnpm run docs
 
   publish:
+    permissions:
+      contents: write
     needs:
       - build
       - test-integration


### PR DESCRIPTION
Potential fix for [https://github.com/decentralized-identity/veramo/security/code-scanning/12](https://github.com/decentralized-identity/veramo/security/code-scanning/12)

To fix the problem, you should add an explicit `permissions:` block to the workflow YAML. For least privilege, add a `permissions:` block at the workflow root that sets default minimal permissions (`contents: read`). For jobs that need broader permissions - such as the `publish` job, which likely needs permission to push tags/releases (i.e., `contents: write`), add a specific `permissions:` block under that job overriding the default. This means:

- Insert a `permissions:` block after the workflow `name:` at the top level (before `on:`) with `contents: read`.
- Under the `publish` job, add a `permissions:` block with `contents: write`.
- No unnecessary changes to job logic or other lines.

No additional imports or dependencies are needed; this is a configuration fix in the workflow YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
