### PR TITLE
chore(ci): limit GH workflow permissions

### DIFF
--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -1,5 +1,7 @@
 name: build-test-on-pr-cached
 on: [pull_request, workflow_dispatch]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-next-with-latest.yml
+++ b/.github/workflows/sync-next-with-latest.yml
@@ -1,4 +1,6 @@
 name: Sync @next with @latest
+permissions:
+  contents: write
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
## What issue is this PR fixing

https://github.com/decentralized-identity/veramo/security/code-scanning/5
https://github.com/decentralized-identity/veramo/security/code-scanning/19
https://github.com/decentralized-identity/veramo/security/code-scanning/20
https://github.com/decentralized-identity/veramo/security/code-scanning/21
https://github.com/decentralized-identity/veramo/security/code-scanning/22
https://github.com/decentralized-identity/veramo/security/code-scanning/23

## What is being changed
Explicitly sets the permissions on GH workflows

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [ ] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [ ] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because no tests are available for GH workflows
