### PR TITLE
chore(ci): update veramo-website repo URL in GH workflow

### DIFF
--- a/.github/workflows/veramo-website.yml
+++ b/.github/workflows/veramo-website.yml
@@ -1,5 +1,8 @@
 name: Trigger veramo-website build
+permissions:
+  contents: read
 on:
+  workflow_dispatch:
   push:
     branches:
       - "main"
@@ -7,12 +10,12 @@ jobs:
   dispatch:
     permissions:
       contents: write
-      actions: write 
+      actions: write
     runs-on: ubuntu-latest
     steps:
       - run: |
           curl -X POST \
             -H 'Authorization: token ${{ secrets.GH_TOKEN }}' \
             -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/uport-project/veramo-website/dispatches \
+            https://api.github.com/repos/veramolabs/veramo-website/dispatches \
             -d '{"event_type":"deploy_website"}'


### PR DESCRIPTION
## What is being changed

The veramo-website repository is now sourced from veramolabs/veramo-website.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [ ] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [ ] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because no functionality has changed.
