### PR TITLE
feat(credential-w3c): refactor the ICredentialProvider API

### DIFF
--- a/__tests__/localAgent.test.ts
+++ b/__tests__/localAgent.test.ts
@@ -7,7 +7,7 @@
  * This suite also runs a ganache local blockchain to run through some examples of DIDComm using did:ethr identifiers.
  */
 
-import { createAgent } from '../packages/core/src'
+import { createAgent, ProofFormat } from '../packages/core/src'
 import {
   IAgentOptions,
   ICredentialPlugin,
@@ -233,7 +233,7 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
         ],
       }),
       new DIDComm({ transports: [new DIDCommHttpTransport()] }),
-      new CredentialPlugin({ issuers: [eip712, jwt, ld] }),
+      new CredentialPlugin([eip712, jwt, ld]),
       new SelectiveDisclosure(),
       new DIDDiscovery({
         providers: [

--- a/__tests__/localAgent.test.ts
+++ b/__tests__/localAgent.test.ts
@@ -7,7 +7,7 @@
  * This suite also runs a ganache local blockchain to run through some examples of DIDComm using did:ethr identifiers.
  */
 
-import { createAgent, ProofFormat } from '../packages/core/src'
+import { createAgent } from '../packages/core/src'
 import {
   IAgentOptions,
   ICredentialPlugin,

--- a/__tests__/localJsonStoreAgent.test.ts
+++ b/__tests__/localJsonStoreAgent.test.ts
@@ -200,21 +200,19 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
         ],
       }),
       new DIDComm(),
-      new CredentialPlugin({
-        issuers: [
-          new CredentialProviderEIP712(),
-          new CredentialProviderJWT(),
-          new CredentialProviderLD({
-            contextMaps: [LdDefaultContexts, credential_contexts as any],
-            suites: [
-              new VeramoEcdsaSecp256k1RecoverySignature2020(),
-              new VeramoEd25519Signature2018(),
-              new VeramoJsonWebSignature2020(),
-              new VeramoEd25519Signature2020(),
-            ],
-          }),
-        ],
-      }),
+      new CredentialPlugin([
+        new CredentialProviderEIP712(),
+        new CredentialProviderJWT(),
+        new CredentialProviderLD({
+          contextMaps: [LdDefaultContexts, credential_contexts as any],
+          suites: [
+            new VeramoEcdsaSecp256k1RecoverySignature2020(),
+            new VeramoEd25519Signature2018(),
+            new VeramoJsonWebSignature2020(),
+            new VeramoEd25519Signature2020(),
+          ],
+        }),
+      ]),
       new SelectiveDisclosure(),
       ...(options?.plugins || []),
     ],

--- a/__tests__/localMemoryStoreAgent.test.ts
+++ b/__tests__/localMemoryStoreAgent.test.ts
@@ -204,7 +204,7 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
         ],
       }),
       new DIDComm(),
-      new CredentialPlugin({ issuers: [eip712, jwt, ld] }),
+      new CredentialPlugin([eip712, jwt, ld]),
       new SelectiveDisclosure(),
       ...(options?.plugins || []),
     ],

--- a/__tests__/restAgent.test.ts
+++ b/__tests__/restAgent.test.ts
@@ -240,7 +240,7 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
       }),
       new DIDComm({ transports: [new DIDCommHttpTransport()] }),
       // intentionally use the deprecated name to test compatibility
-      new CredentialIssuer({ issuers: [eip712, jwt, ld] }),
+      new CredentialIssuer([eip712, jwt, ld]),
       new SelectiveDisclosure(),
       new DIDDiscovery({
         providers: [

--- a/packages/core-types/src/plugin.schema.ts
+++ b/packages/core-types/src/plugin.schema.ts
@@ -2368,7 +2368,7 @@ export const schema = {
             "id",
             "type"
           ],
-          "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information is determined by the specific `credentialStatus` type definition, and varies depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
+          "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information are determined by the specific `credentialStatus` type  definition and vary depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
         },
         "VerifiablePresentation": {
           "type": "object",
@@ -2433,7 +2433,7 @@ export const schema = {
               "$ref": "#/components/schemas/CompactJWT"
             }
           ],
-          "description": "Represents a signed Verifiable Credential (includes proof), in either JSON or compact JWT format. See  {@link https://www.w3.org/TR/vc-data-model/#credentials | VC data model }  See  {@link https://www.w3.org/TR/vc-data-model/#proof-formats | proof formats }"
+          "description": "Represents a signed Verifiable Credential (includes proof), in either JSON or compact JWT format. See  {@link https://www.w3.org/TR/vc-data-model/#credentials | VC data model }  See  {@link https://www.w3.org/TR/vc-data-model-1.1/#proof-formats | proof formats }"
         },
         "CompactJWT": {
           "type": "string",
@@ -3234,7 +3234,7 @@ export const schema = {
             "id",
             "type"
           ],
-          "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information is determined by the specific `credentialStatus` type definition, and varies depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
+          "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information are determined by the specific `credentialStatus` type  definition and vary depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
         },
         "VerifiablePresentation": {
           "type": "object",
@@ -3299,7 +3299,7 @@ export const schema = {
               "$ref": "#/components/schemas/CompactJWT"
             }
           ],
-          "description": "Represents a signed Verifiable Credential (includes proof), in either JSON or compact JWT format. See  {@link https://www.w3.org/TR/vc-data-model/#credentials | VC data model }  See  {@link https://www.w3.org/TR/vc-data-model/#proof-formats | proof formats }"
+          "description": "Represents a signed Verifiable Credential (includes proof), in either JSON or compact JWT format. See  {@link https://www.w3.org/TR/vc-data-model/#credentials | VC data model }  See  {@link https://www.w3.org/TR/vc-data-model-1.1/#proof-formats | proof formats }"
         },
         "CompactJWT": {
           "type": "string",
@@ -4083,7 +4083,7 @@ export const schema = {
             "id",
             "type"
           ],
-          "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information is determined by the specific `credentialStatus` type definition, and varies depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
+          "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information are determined by the specific `credentialStatus` type  definition and vary depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
         },
         "VerifiablePresentation": {
           "type": "object",
@@ -4148,7 +4148,7 @@ export const schema = {
               "$ref": "#/components/schemas/CompactJWT"
             }
           ],
-          "description": "Represents a signed Verifiable Credential (includes proof), in either JSON or compact JWT format. See  {@link https://www.w3.org/TR/vc-data-model/#credentials | VC data model }  See  {@link https://www.w3.org/TR/vc-data-model/#proof-formats | proof formats }"
+          "description": "Represents a signed Verifiable Credential (includes proof), in either JSON or compact JWT format. See  {@link https://www.w3.org/TR/vc-data-model/#credentials | VC data model }  See  {@link https://www.w3.org/TR/vc-data-model-1.1/#proof-formats | proof formats }"
         },
         "CompactJWT": {
           "type": "string",
@@ -4388,10 +4388,11 @@ export const schema = {
             "id",
             "type"
           ],
-          "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information is determined by the specific `credentialStatus` type definition, and varies depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
+          "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information are determined by the specific `credentialStatus` type  definition and vary depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
         },
         "ProofFormat": {
-          "type": "string"
+          "type": "string",
+          "description": "Represents a format for a particular type of verifiable data. This is an extensible union of several known formats implemented by Veramo"
         },
         "VerifiableCredential": {
           "type": "object",
@@ -4564,7 +4565,7 @@ export const schema = {
               "$ref": "#/components/schemas/CompactJWT"
             }
           ],
-          "description": "Represents a signed Verifiable Credential (includes proof), in either JSON or compact JWT format. See  {@link https://www.w3.org/TR/vc-data-model/#credentials | VC data model }  See  {@link https://www.w3.org/TR/vc-data-model/#proof-formats | proof formats }"
+          "description": "Represents a signed Verifiable Credential (includes proof), in either JSON or compact JWT format. See  {@link https://www.w3.org/TR/vc-data-model/#credentials | VC data model }  See  {@link https://www.w3.org/TR/vc-data-model-1.1/#proof-formats | proof formats }"
         },
         "CompactJWT": {
           "type": "string",
@@ -4798,7 +4799,7 @@ export const schema = {
           }
         },
         "listUsableProofFormats": {
-          "description": "Returns a list of supported proof formats.",
+          "description": "Returns a list of supported proof formats for verifiable data that this plugin can generate based on the specified issuer.",
           "arguments": {
             "$ref": "#/components/schemas/IIdentifier"
           },
@@ -4832,11 +4833,11 @@ export const schema = {
             },
             "credential": {
               "$ref": "#/components/schemas/W3CVerifiableCredential",
-              "description": "The Verifiable Credential object according to the  {@link https://www.w3.org/TR/vc-data-model/#credentials | canonical model }  or the JWT representation.\n\nThe signer of the Credential is verified based on the `issuer.id` property of the `credential` or the `iss` property of the JWT payload respectively"
+              "description": "The Verifiable Credential object according to the  {@link https://www.w3.org/TR/vc-data-model/#credentials | canonical model }  or the  {@link https://www.w3.org/TR/vc-data-model-1.1/#json-web-token | JWT representation } .\n\nThe signer of the Credential is verified based on the `issuer.id` property of the `credential` or the `iss` property of the JWT payload respectively"
             },
             "fetchRemoteContexts": {
               "type": "boolean",
-              "description": "When dealing with JSON-LD you also MUST provide the proper contexts. Set this to `true` ONLY if you want the `@context` URLs to be fetched in case they are not preloaded. The context definitions SHOULD rather be provided at startup instead of being fetched.\n\nDefaults to `false`"
+              "description": "When dealing with JSON-LD you also MUST provide the proper contexts. Set this to `true` ONLY if you want the `@context` URLs to be fetched in case they are not preloaded. The context definitions SHOULD rather be provided at application startup instead of being fetched.\n\nDefaults to `false`"
             },
             "policies": {
               "$ref": "#/components/schemas/VerificationPolicies",
@@ -4860,7 +4861,7 @@ export const schema = {
               "$ref": "#/components/schemas/CompactJWT"
             }
           ],
-          "description": "Represents a signed Verifiable Credential (includes proof), in either JSON or compact JWT format. See  {@link https://www.w3.org/TR/vc-data-model/#credentials | VC data model }  See  {@link https://www.w3.org/TR/vc-data-model/#proof-formats | proof formats }"
+          "description": "Represents a signed Verifiable Credential (includes proof), in either JSON or compact JWT format. See  {@link https://www.w3.org/TR/vc-data-model/#credentials | VC data model }  See  {@link https://www.w3.org/TR/vc-data-model-1.1/#proof-formats | proof formats }"
         },
         "VerifiableCredential": {
           "type": "object",
@@ -4990,7 +4991,7 @@ export const schema = {
             "id",
             "type"
           ],
-          "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information is determined by the specific `credentialStatus` type definition, and varies depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
+          "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information are determined by the specific `credentialStatus` type  definition and vary depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
         },
         "CompactJWT": {
           "type": "string",
@@ -5363,7 +5364,7 @@ export const schema = {
             "id",
             "type"
           ],
-          "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information is determined by the specific `credentialStatus` type definition, and varies depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
+          "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information are determined by the specific `credentialStatus` type  definition and vary depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
         },
         "DIDDocument": {
           "type": "object",
@@ -5697,7 +5698,7 @@ export const schema = {
           "required": [
             "revoked"
           ],
-          "description": "Represents the result of a status check.\n\nImplementations MUST populate the `revoked` boolean property, but they can return additional metadata that is method specific."
+          "description": "Represents the result of a status check.\n\nImplementations MUST populate the `revoked` boolean property, but they can return additional metadata that is method-specific."
         }
       },
       "methods": {
@@ -5746,7 +5747,7 @@ export const schema = {
             "id",
             "type"
           ],
-          "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information is determined by the specific `credentialStatus` type definition, and varies depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
+          "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information are determined by the specific `credentialStatus` type  definition and vary depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
         },
         "CredentialStatusUpdateArgs": {
           "type": "object",

--- a/packages/core-types/src/plugin.schema.ts
+++ b/packages/core-types/src/plugin.schema.ts
@@ -4249,7 +4249,7 @@ export const schema = {
               "deprecated": "Please call\n{@link @veramo/core-types#IDataStore.dataStoreSaveVerifiableCredential | dataStoreSaveVerifiableCredential()} to\nsave the credential after creating it."
             },
             "proofFormat": {
-              "type": "string",
+              "$ref": "#/components/schemas/ProofFormat",
               "description": "The desired format for the VerifiableCredential to be created."
             },
             "removeOriginalFields": {
@@ -4262,7 +4262,7 @@ export const schema = {
             },
             "fetchRemoteContexts": {
               "type": "boolean",
-              "description": "When dealing with JSON-LD you also MUST provide the proper contexts. Set this to `true` ONLY if you want the `@context` URLs to be fetched in case they are not preloaded. The context definitions SHOULD rather be provided at startup instead of being fetched.\n\nDefaults to `false`"
+              "description": "When dealing with JSON-LD, you also MUST provide the proper contexts. Set this to `true` ONLY if you want the `@context` URLs to be fetched in case they are not preloaded. The context definitions SHOULD rather be provided at startup instead of being fetched.\n\nDefaults to `false`"
             }
           },
           "required": [
@@ -4390,6 +4390,9 @@ export const schema = {
           ],
           "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information is determined by the specific `credentialStatus` type definition, and varies depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
         },
+        "ProofFormat": {
+          "type": "string"
+        },
         "VerifiableCredential": {
           "type": "object",
           "properties": {
@@ -4485,7 +4488,7 @@ export const schema = {
               "description": "Optional string domain parameter to add to the verifiable presentation."
             },
             "proofFormat": {
-              "type": "string",
+              "$ref": "#/components/schemas/ProofFormat",
               "description": "The desired format for the VerifiablePresentation to be created."
             },
             "removeOriginalFields": {
@@ -4498,7 +4501,7 @@ export const schema = {
             },
             "fetchRemoteContexts": {
               "type": "boolean",
-              "description": "When dealing with JSON-LD you also MUST provide the proper contexts. Set this to `true` ONLY if you want the `@context` URLs to be fetched in case they are not preloaded. The context definitions SHOULD rather be provided at startup instead of being fetched.\n\nDefaults to `false`"
+              "description": "When dealing with JSON-LD, you also MUST provide the proper contexts. Set this to `true` ONLY if you want the `@context` URLs to be fetched in case they are not preloaded. The context definitions SHOULD rather be provided at startup instead of being fetched.\n\nDefaults to `false`"
             }
           },
           "required": [
@@ -4777,7 +4780,7 @@ export const schema = {
       },
       "methods": {
         "createVerifiableCredential": {
-          "description": "Creates a Verifiable Credential. The payload, signer and format are chosen based on the ",
+          "description": "Creates a Verifiable Credential. The payload, signer, and format are chosen based on the ",
           "arguments": {
             "$ref": "#/components/schemas/ICreateVerifiableCredentialArgs"
           },
@@ -4802,7 +4805,7 @@ export const schema = {
           "returnType": {
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/ProofFormat"
             }
           }
         }

--- a/packages/core-types/src/types/ICredentialIssuer.ts
+++ b/packages/core-types/src/types/ICredentialIssuer.ts
@@ -9,14 +9,27 @@ import { IResolver } from './IResolver.js'
 import { IDIDManager } from './IDIDManager.js'
 import { IDataStore } from './IDataStore.js'
 import { IKeyManager } from './IKeyManager.js'
-import { IIdentifier, IKey } from "./IIdentifier.js";
+import { IIdentifier, IKey } from './IIdentifier.js'
 import { UsingResolutionOptions } from './ICredentialVerifier.js'
 
+/**
+ * Constants representing internally supported proof formats.
+ *
+ * @internal
+ */
+export const PROOF_FORMAT = {
+  ETHEREUM_EIP712_SIGNATURE_2021: 'EthereumEip712Signature2021',
+  JWT: 'jwt',
+  LD_SIGNATURE: 'lds',
+  BBS_PLUS: 'bbs+',
+} as const
+
 /*
-*
-* @public
-*/
-export type ProofFormat = 'jwt' | 'lds' | 'EthereumEip712Signature2021' | 'bbs' | string
+ * Represents a format for a particular type of verifiable data.
+ * This is an extensible union of several known formats implemented by Veramo
+ * @public
+ */
+export type ProofFormat = (typeof PROOF_FORMAT)[keyof typeof PROOF_FORMAT] | (string & {})
 
 /**
  * Encapsulates the parameters required to create a
@@ -59,7 +72,7 @@ export interface ICreateVerifiablePresentationArgs extends UsingResolutionOption
   /**
    * The desired format for the VerifiablePresentation to be created.
    */
-  proofFormat: string
+  proofFormat: ProofFormat
 
   /**
    * Remove payload members during JWT-JSON transformation. Defaults to `true`.
@@ -74,7 +87,7 @@ export interface ICreateVerifiablePresentationArgs extends UsingResolutionOption
   keyRef?: string
 
   /**
-   * When dealing with JSON-LD you also MUST provide the proper contexts.
+   * When dealing with JSON-LD, you also MUST provide the proper contexts.
    * Set this to `true` ONLY if you want the `@context` URLs to be fetched in case they are not preloaded.
    * The context definitions SHOULD rather be provided at startup instead of being fetched.
    *
@@ -119,7 +132,7 @@ export interface ICreateVerifiableCredentialArgs extends UsingResolutionOptions 
   /**
    * The desired format for the VerifiableCredential to be created.
    */
-  proofFormat: string
+  proofFormat: ProofFormat
 
   /**
    * Remove payload members during JWT-JSON transformation. Defaults to `true`.
@@ -134,7 +147,7 @@ export interface ICreateVerifiableCredentialArgs extends UsingResolutionOptions 
   keyRef?: string
 
   /**
-   * When dealing with JSON-LD you also MUST provide the proper contexts.
+   * When dealing with JSON-LD, you also MUST provide the proper contexts.
    * Set this to `true` ONLY if you want the `@context` URLs to be fetched in case they are not preloaded.
    * The context definitions SHOULD rather be provided at startup instead of being fetched.
    *
@@ -157,11 +170,11 @@ export interface ICreateVerifiableCredentialArgs extends UsingResolutionOptions 
 
 /**
  * Encapsulates the parameters required to check if a credential type can be issued
- * 
+ *
  * @public
  */
 export interface ICanIssueCredentialTypeArgs {
-  proofFormat: string
+  proofFormat: ProofFormat
 }
 
 /**
@@ -193,7 +206,7 @@ export interface ICredentialIssuer extends IPluginMethodMap {
 
   /**
    * Creates a Verifiable Credential.
-   * The payload, signer and format are chosen based on the `args` parameter.
+   * The payload, signer, and format are chosen based on the `args` parameter.
    *
    * @param args - Arguments necessary to create the Presentation.
    * @param context - This reserved param is automatically added and handled by the framework, *do not override*
@@ -215,21 +228,20 @@ export interface ICredentialIssuer extends IPluginMethodMap {
    *
    * @beta This API may change without a BREAKING CHANGE notice.
    */
-  listUsableProofFormats(identifier: IIdentifier, context: IAgentContext<{}>): Promise<Array<string>>
-
+  listUsableProofFormats(identifier: IIdentifier, context: IAgentContext<{}>): Promise<Array<ProofFormat>>
 }
 
 /**
  * Represents the requirements that this plugin has.
- * The agent that is using this plugin is expected to provide these methods.
+ * The agent using this plugin is expected to provide these methods.
  *
- * This interface can be used for static type checks, to make sure your application is properly initialized.
+ * This interface can be used for static type checks to make sure your application is properly initialized.
  *
  * @beta
  */
 export type IssuerAgentContext = IAgentContext<
   IResolver &
-  Pick<IDIDManager, 'didManagerGet' | 'didManagerFind'> &
-  Pick<IDataStore, 'dataStoreSaveVerifiablePresentation' | 'dataStoreSaveVerifiableCredential'> &
-  Pick<IKeyManager, 'keyManagerGet' | 'keyManagerSign'>
+    Pick<IDIDManager, 'didManagerGet' | 'didManagerFind'> &
+    Pick<IDataStore, 'dataStoreSaveVerifiablePresentation' | 'dataStoreSaveVerifiableCredential'> &
+    Pick<IKeyManager, 'keyManagerGet' | 'keyManagerSign'>
 >

--- a/packages/core-types/src/types/ICredentialIssuer.ts
+++ b/packages/core-types/src/types/ICredentialIssuer.ts
@@ -9,7 +9,7 @@ import { IResolver } from './IResolver.js'
 import { IDIDManager } from './IDIDManager.js'
 import { IDataStore } from './IDataStore.js'
 import { IKeyManager } from './IKeyManager.js'
-import { IIdentifier, IKey } from './IIdentifier.js'
+import { IIdentifier } from './IIdentifier.js'
 import { UsingResolutionOptions } from './ICredentialVerifier.js'
 
 /**
@@ -24,7 +24,7 @@ export const PROOF_FORMAT = {
   BBS_PLUS: 'bbs+',
 } as const
 
-/*
+/**
  * Represents a format for a particular type of verifiable data.
  * This is an extensible union of several known formats implemented by Veramo
  * @public
@@ -162,22 +162,6 @@ export interface ICreateVerifiableCredentialArgs extends UsingResolutionOptions 
 }
 
 /**
- * Encapsulates the response object to verifyPresentation method after verifying a
- * {@link https://www.w3.org/TR/vc-data-model/#presentations | W3C Verifiable Presentation}
- *
- * @public
- */
-
-/**
- * Encapsulates the parameters required to check if a credential type can be issued
- *
- * @public
- */
-export interface ICanIssueCredentialTypeArgs {
-  proofFormat: ProofFormat
-}
-
-/**
  * The interface definition for a plugin that can generate Verifiable Credentials and Presentations
  *
  * @see {@link @veramo/credential-w3c#CredentialPlugin} for an implementation.
@@ -222,7 +206,7 @@ export interface ICredentialIssuer extends IPluginMethodMap {
   ): Promise<VerifiableCredential>
 
   /**
-   * Returns a list of supported proof formats.
+   * Returns a list of supported proof formats for verifiable data that this plugin can generate based on the specified issuer.
    * @param identifier - The identifier that may be used to sign a credential or presentation
    * @param context - This reserved param is automatically added and handled by the framework, *do not override*
    *

--- a/packages/core-types/src/types/ICredentialVerifier.ts
+++ b/packages/core-types/src/types/ICredentialVerifier.ts
@@ -28,7 +28,8 @@ export interface UsingResolutionOptions {
 export interface IVerifyCredentialArgs extends UsingResolutionOptions {
   /**
    * The Verifiable Credential object according to the
-   * {@link https://www.w3.org/TR/vc-data-model/#credentials | canonical model} or the JWT representation.
+   * {@link https://www.w3.org/TR/vc-data-model/#credentials | canonical model} or
+   * the {@link https://www.w3.org/TR/vc-data-model-1.1/#json-web-token | JWT representation}.
    *
    * The signer of the Credential is verified based on the `issuer.id` property
    * of the `credential` or the `iss` property of the JWT payload respectively
@@ -39,7 +40,7 @@ export interface IVerifyCredentialArgs extends UsingResolutionOptions {
   /**
    * When dealing with JSON-LD you also MUST provide the proper contexts.
    * Set this to `true` ONLY if you want the `@context` URLs to be fetched in case they are not preloaded.
-   * The context definitions SHOULD rather be provided at startup instead of being fetched.
+   * The context definitions SHOULD rather be provided at application startup instead of being fetched.
    *
    * Defaults to `false`
    */
@@ -142,18 +143,6 @@ export interface VerificationPolicies {
    * They will be forwarded to the lower level modules that perform the checks
    */
   [x: string]: any
-}
-
-/**
- * Encapsulates the parameters required to check if a document can be verified
- * 
- * @public
- */
-export interface ICanVerifyDocumentTypeArgs {
-  /**
-   * The document to check against the verifier
-   */
-  document: W3CVerifiableCredential | W3CVerifiablePresentation
 }
 
 /**

--- a/packages/core-types/src/types/vc-data-model.ts
+++ b/packages/core-types/src/types/vc-data-model.ts
@@ -37,8 +37,8 @@ export type CredentialSubject = {
 /**
  * Used for the discovery of information about the current status of a verifiable credential, such as whether it is
  * suspended or revoked.
- * The precise contents of the credential status information is determined by the specific `credentialStatus` type
- * definition, and varies depending on factors such as whether it is simple to implement or if it is privacy-enhancing.
+ * The precise contents of the credential status information are determined by the specific `credentialStatus` type
+ *  definition and vary depending on factors such as whether it is simple to implement or if it is privacy-enhancing.
  *
  * See {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status}
  *
@@ -54,7 +54,7 @@ export type CredentialStatusReference = {
  * Represents the result of a status check.
  *
  * Implementations MUST populate the `revoked` boolean property, but they can return additional metadata that is
- * method specific.
+ * method-specific.
  *
  * @see {@link credential-status#CredentialStatus | CredentialStatus}
  *
@@ -115,7 +115,7 @@ export type VerifiableCredential = UnsignedCredential & { proof: ProofType }
 /**
  * Represents a signed Verifiable Credential (includes proof), in either JSON or compact JWT format.
  * See {@link https://www.w3.org/TR/vc-data-model/#credentials | VC data model}
- * See {@link https://www.w3.org/TR/vc-data-model/#proof-formats | proof formats}
+ * See {@link https://www.w3.org/TR/vc-data-model-1.1/#proof-formats | proof formats}
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */

--- a/packages/credential-eip712/src/__tests__/issue-verify-flow-eip712.test.ts
+++ b/packages/credential-eip712/src/__tests__/issue-verify-flow-eip712.test.ts
@@ -14,11 +14,9 @@ import { KeyManager, MemoryKeyStore, MemoryPrivateKeyStore } from '../../../key-
 import { KeyManagementSystem } from '../../../kms-local/src/index.js'
 import { getDidKeyResolver, KeyDIDProvider } from '../../../did-provider-key/src/index.js'
 import { DIDResolverPlugin } from '../../../did-resolver/src/index.js'
-import { Resolver } from 'did-resolver'
+import { CredentialProviderEIP712 } from '../agent/CredentialProviderEIP712.js'
 
-import { CredentialProviderJWT } from '../agent/CredentialProviderJWT.js'
-
-describe('credential-jwt full flow', () => {
+describe('Issue and Verify Flow EIP712', () => {
   let didKeyIdentifier: IIdentifier
   let agent: TAgent<IResolver & IKeyManager & IDIDManager & ICredentialPlugin>
 
@@ -39,30 +37,25 @@ describe('credential-jwt full flow', () => {
           defaultProvider: 'did:key',
         }),
         new DIDResolverPlugin({
-          resolver: new Resolver({
-            ...getDidKeyResolver(),
-          }),
+          ...getDidKeyResolver(),
         }),
-        new CredentialPlugin([new CredentialProviderJWT()]),
+        new CredentialPlugin([new CredentialProviderEIP712()]),
       ],
     })
-    didKeyIdentifier = await agent.didManagerCreate()
+    didKeyIdentifier = await agent.didManagerCreate({ options: { key: { type: 'Secp256k1' } } })
   })
 
-  it('issues and verifies JWT credential', async () => {
+  it('issues and verifies EIP712 credential', async () => {
     const credential: CredentialPayload = {
       issuer: { id: didKeyIdentifier.did },
-      '@context': ['https://www.w3.org/2018/credentials/v1', 'https://example.com/1/2/3'],
-      type: ['VerifiableCredential', 'Custom'],
-      issuanceDate: new Date().toISOString(),
+      type: ['VerifiableCredential'],
       credentialSubject: {
-        id: 'did:web:example.com',
-        you: 'Rock',
+        id: 'hello',
       },
     }
     const verifiableCredential = await agent.createVerifiableCredential({
       credential,
-      proofFormat: 'jwt',
+      proofFormat: 'EthereumEip712Signature2021',
     })
 
     expect(verifiableCredential).toBeDefined()
@@ -74,38 +67,65 @@ describe('credential-jwt full flow', () => {
     expect(result.verified).toBe(true)
   })
 
-  it('issues credential and verifies presentation', async () => {
+  it('fails to verify a tampered EIP712 credential', async () => {
     const credential: CredentialPayload = {
       issuer: { id: didKeyIdentifier.did },
-      '@context': ['https://www.w3.org/2018/credentials/v1', 'https://veramo.io/contexts/profile/v1'],
-      type: ['VerifiableCredential', 'Profile'],
-      issuanceDate: new Date().toISOString(),
+      type: ['VerifiableCredential'],
       credentialSubject: {
-        id: didKeyIdentifier.did,
-        name: 'Martin, the great',
+        id: 'hello',
+      },
+    }
+    const verifiableCredential = await agent.createVerifiableCredential({
+      credential,
+      proofFormat: 'EthereumEip712Signature2021',
+    })
+
+    expect(verifiableCredential).toBeDefined()
+
+    // Tamper with the credential
+    if (typeof verifiableCredential === 'object' && 'credentialSubject' in verifiableCredential) {
+      verifiableCredential.credentialSubject['id'] = 'tampered'
+    }
+
+    const result = await agent.verifyCredential({
+      credential: verifiableCredential,
+    })
+
+    console.log(result)
+
+    expect(result.verified).toBe(false)
+    expect(result.error).toEqual({
+      errorCode: 'invalid_signature',
+      message: 'invalid_signature: The signature does not match any of the issuer signing keys',
+    })
+  })
+
+  it('issues and verifies EIP712 presentation', async () => {
+    const credential: CredentialPayload = {
+      issuer: { id: didKeyIdentifier.did },
+      type: ['VerifiableCredential'],
+      credentialSubject: {
+        id: 'hello',
       },
     }
     const verifiableCredential1 = await agent.createVerifiableCredential({
       credential,
-      proofFormat: 'jwt',
+      proofFormat: 'EthereumEip712Signature2021',
     })
-
     const verifiablePresentation = await agent.createVerifiablePresentation({
       presentation: {
         verifiableCredential: [verifiableCredential1],
         holder: didKeyIdentifier.did,
       },
       challenge: 'VERAMO',
-      proofFormat: 'jwt',
+      proofFormat: 'EthereumEip712Signature2021',
     })
-
     expect(verifiablePresentation).toBeDefined()
 
     const result = await agent.verifyPresentation({
       presentation: verifiablePresentation,
       challenge: 'VERAMO',
     })
-
     expect(result.verified).toBe(true)
   })
 })

--- a/packages/credential-eip712/src/__tests__/issue-verify-flow-eip712.test.ts
+++ b/packages/credential-eip712/src/__tests__/issue-verify-flow-eip712.test.ts
@@ -91,8 +91,6 @@ describe('Issue and Verify Flow EIP712', () => {
       credential: verifiableCredential,
     })
 
-    console.log(result)
-
     expect(result.verified).toBe(false)
     expect(result.error).toEqual({
       errorCode: 'invalid_signature',

--- a/packages/credential-eip712/src/agent/CredentialProviderEIP712.ts
+++ b/packages/credential-eip712/src/agent/CredentialProviderEIP712.ts
@@ -1,21 +1,20 @@
 import {
   CredentialPayload,
-  IAgentPlugin,
-  ICreateVerifiableCredentialArgs,
   ICanIssueCredentialTypeArgs,
+  ICanVerifyDocumentTypeArgs,
+  ICreateVerifiableCredentialArgs,
+  ICreateVerifiablePresentationArgs,
   IIdentifier,
   IKey,
   IssuerAgentContext,
+  IVerifyCredentialArgs,
+  IVerifyPresentationArgs,
+  IVerifyResult,
   PresentationPayload,
+  PROOF_FORMAT,
   VerifiableCredential,
   VerifiablePresentation,
-  ICreateVerifiablePresentationArgs,
-  IVerifyCredentialArgs,
-  IVerifyResult,
-  IVerifyPresentationArgs,
   VerifierAgentContext,
-  IAgentContext,
-  ICanVerifyDocumentTypeArgs,
 } from '@veramo/core-types'
 import {
   extractIssuer,
@@ -29,38 +28,35 @@ import {
   removeDIDParameters,
   resolveDidOrThrow,
 } from '@veramo/utils'
-import { AbstractCredentialProvider } from '@veramo/credential-w3c'
+import { ICredentialProvider } from '@veramo/credential-w3c'
 
 import { recoverTypedSignature, SignTypedDataVersion } from '@metamask/eth-sig-util'
 
 import { getEthTypesFromInputDoc } from 'eip-712-types-generation'
 
 /**
- * A Veramo plugin that implements the {@link ICredentialProviderEIP712} methods.
+ * A Veramo Credential sub-plugin that implements the {@link ICredentialProvider} methods.
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
-export class CredentialProviderEIP712 implements AbstractCredentialProvider {
-
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.matchKeyForType} */
-  matchKeyForType(key: IKey): boolean {
-    return this.matchKeyForEIP712(key)
-  }
-
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.getTypeProofFormat} */
-  getTypeProofFormat(): string {
-    return 'EthereumEip712Signature2021'
+export class CredentialProviderEIP712 implements ICredentialProvider {
+  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.getProofFormatsSupportedForKey} */
+  getProofFormatsSupportedForKey(key: IKey): string[] {
+    if (this.matchKeyForEIP712(key)) {
+      return [PROOF_FORMAT.ETHEREUM_EIP712_SIGNATURE_2021]
+    }
+    return []
   }
 
   /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.canIssueCredentialType} */
-  canIssueCredentialType(args: ICanIssueCredentialTypeArgs): boolean {
-    return (args.proofFormat === 'EthereumEip712Signature2021')
+  async canIssueCredentialType(args: ICanIssueCredentialTypeArgs): Promise<boolean> {
+    return args.proofFormat === PROOF_FORMAT.ETHEREUM_EIP712_SIGNATURE_2021
   }
 
   /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.canVerifyDocumentType */
   canVerifyDocumentType(args: ICanVerifyDocumentTypeArgs): boolean {
     const { document } = args
-    return ((<VerifiableCredential>document)?.proof?.type === 'EthereumEip712Signature2021')
+    return (<VerifiableCredential>document)?.proof?.type === PROOF_FORMAT.ETHEREUM_EIP712_SIGNATURE_2021
   }
 
   /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.createVerifiableCredential} */
@@ -120,7 +116,7 @@ export class CredentialProviderEIP712 implements AbstractCredentialProvider {
         verificationMethod: extendedKey.meta.verificationMethod.id,
         created: issuanceDate,
         proofPurpose: 'assertionMethod',
-        type: 'EthereumEip712Signature2021',
+        type: PROOF_FORMAT.ETHEREUM_EIP712_SIGNATURE_2021,
       },
     }
 
@@ -137,9 +133,11 @@ export class CredentialProviderEIP712 implements AbstractCredentialProvider {
 
     const data = JSON.stringify({ domain, types, message, primaryType })
 
-    const signature = await context.agent.keyManagerSign({ keyRef, data, algorithm: 'eth_signTypedData' })
-
-    credential['proof']['proofValue'] = signature
+    credential['proof']['proofValue'] = await context.agent.keyManagerSign({
+      keyRef,
+      data,
+      algorithm: 'eth_signTypedData',
+    })
     credential['proof']['eip712'] = {
       domain,
       types: allTypes,
@@ -150,10 +148,7 @@ export class CredentialProviderEIP712 implements AbstractCredentialProvider {
   }
 
   /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.verifyCredential} */
-  async verifyCredential(
-    args: IVerifyCredentialArgs,
-    context: VerifierAgentContext,
-  ): Promise<IVerifyResult> {
+  async verifyCredential(args: IVerifyCredentialArgs, context: VerifierAgentContext): Promise<IVerifyResult> {
     const credential = args.credential as VerifiableCredential
     if (!credential.proof || !credential.proof.proofValue)
       throw new Error('invalid_argument: proof is undefined')
@@ -212,7 +207,7 @@ export class CredentialProviderEIP712 implements AbstractCredentialProvider {
       error: {
         message: 'invalid_signature: The signature does not match any of the issuer signing keys',
         errorCode: 'invalid_signature',
-      }
+      },
     }
   }
 
@@ -296,7 +291,7 @@ export class CredentialProviderEIP712 implements AbstractCredentialProvider {
       verificationMethod: extendedKey.meta.verificationMethod.id,
       created: issuanceDate,
       proofPurpose: 'assertionMethod',
-      type: 'EthereumEip712Signature2021',
+      type: PROOF_FORMAT.ETHEREUM_EIP712_SIGNATURE_2021,
     }
 
     const message = presentation
@@ -312,9 +307,11 @@ export class CredentialProviderEIP712 implements AbstractCredentialProvider {
 
     const data = JSON.stringify({ domain, types, message })
 
-    const signature = await context.agent.keyManagerSign({ keyRef, data, algorithm: 'eth_signTypedData' })
-
-    presentation.proof.proofValue = signature
+    presentation.proof.proofValue = await context.agent.keyManagerSign({
+      keyRef,
+      data,
+      algorithm: 'eth_signTypedData',
+    })
 
     presentation.proof.eip712 = {
       domain,
@@ -387,7 +384,7 @@ export class CredentialProviderEIP712 implements AbstractCredentialProvider {
       error: {
         message: 'invalid_signature: The signature does not match any of the holder signing keys',
         errorCode: 'invalid_signature',
-      }
+      },
     }
   }
 
@@ -401,7 +398,8 @@ export class CredentialProviderEIP712 implements AbstractCredentialProvider {
    */
   matchKeyForEIP712(k: IKey): boolean {
     return (
-      intersect(k.meta?.algorithms ?? [], ['eth_signTypedData', 'EthereumEip712Signature2021']).length > 0
+      intersect(k.meta?.algorithms ?? [], ['eth_signTypedData', PROOF_FORMAT.ETHEREUM_EIP712_SIGNATURE_2021])
+        .length > 0
     )
   }
 }

--- a/packages/credential-eip712/src/agent/CredentialProviderEIP712.ts
+++ b/packages/credential-eip712/src/agent/CredentialProviderEIP712.ts
@@ -10,6 +10,7 @@ import {
   IVerifyResult,
   PresentationPayload,
   PROOF_FORMAT,
+  ProofFormat,
   VerifiableCredential,
   VerifiablePresentation,
   VerifierAgentContext,
@@ -43,7 +44,7 @@ import { getEthTypesFromInputDoc } from 'eip-712-types-generation'
  */
 export class CredentialProviderEIP712 implements ICredentialProvider {
   /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.getProofFormatsSupportedForKey} */
-  getProofFormatsSupportedForKey(key: IKey): string[] {
+  getProofFormatsSupportedForKey(key: IKey): ProofFormat[] {
     if (this.matchKeyForEIP712(key)) {
       return [PROOF_FORMAT.ETHEREUM_EIP712_SIGNATURE_2021]
     }

--- a/packages/credential-eip712/src/agent/CredentialProviderEIP712.ts
+++ b/packages/credential-eip712/src/agent/CredentialProviderEIP712.ts
@@ -1,7 +1,5 @@
 import {
   CredentialPayload,
-  ICanIssueCredentialTypeArgs,
-  ICanVerifyDocumentTypeArgs,
   ICreateVerifiableCredentialArgs,
   ICreateVerifiablePresentationArgs,
   IIdentifier,
@@ -28,19 +26,23 @@ import {
   removeDIDParameters,
   resolveDidOrThrow,
 } from '@veramo/utils'
-import { ICredentialProvider } from '@veramo/credential-w3c'
+import { ICredentialProvider, ProofFormatQuery, TentativeVerificationQuery } from '@veramo/credential-w3c'
 
 import { recoverTypedSignature, SignTypedDataVersion } from '@metamask/eth-sig-util'
 
 import { getEthTypesFromInputDoc } from 'eip-712-types-generation'
 
 /**
- * A Veramo Credential sub-plugin that implements the {@link ICredentialProvider} methods.
+ * A Veramo Credential sub-plugin that implements
+ * a {@link @veramo/credential-w3c#ICredentialProvider | ICredentialProvider} with support for
+ * EthereumEIP712Signature2021 proofs.
  *
  * @beta This API may change without a BREAKING CHANGE notice.
+ * @see {@link https://w3c-ccg.github.io/ethereum-eip712-signature-2021-spec/ | EthereumEIP712Signature2021 spec }
+ * @see {@link https://www.w3.org/TR/vc-data-model-1.1/ | VC 1.1 data model}.
  */
 export class CredentialProviderEIP712 implements ICredentialProvider {
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.getProofFormatsSupportedForKey} */
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.getProofFormatsSupportedForKey} */
   getProofFormatsSupportedForKey(key: IKey): string[] {
     if (this.matchKeyForEIP712(key)) {
       return [PROOF_FORMAT.ETHEREUM_EIP712_SIGNATURE_2021]
@@ -48,18 +50,18 @@ export class CredentialProviderEIP712 implements ICredentialProvider {
     return []
   }
 
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.canIssueCredentialType} */
-  async canIssueCredentialType(args: ICanIssueCredentialTypeArgs): Promise<boolean> {
-    return args.proofFormat === PROOF_FORMAT.ETHEREUM_EIP712_SIGNATURE_2021
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.canIssueCredentialType} */
+  canIssueProofFormat(query: ProofFormatQuery): boolean {
+    return query.proofFormat === PROOF_FORMAT.ETHEREUM_EIP712_SIGNATURE_2021
   }
 
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.canVerifyDocumentType */
-  canVerifyDocumentType(args: ICanVerifyDocumentTypeArgs): boolean {
-    const { document } = args
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.canVerifyDocumentType} */
+  canVerifyDocumentType(query: TentativeVerificationQuery): boolean {
+    const { document } = query
     return (<VerifiableCredential>document)?.proof?.type === PROOF_FORMAT.ETHEREUM_EIP712_SIGNATURE_2021
   }
 
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.createVerifiableCredential} */
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.createVerifiableCredential} */
   async createVerifiableCredential(
     args: ICreateVerifiableCredentialArgs,
     context: IssuerAgentContext,
@@ -147,7 +149,7 @@ export class CredentialProviderEIP712 implements ICredentialProvider {
     return credential as VerifiableCredential
   }
 
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.verifyCredential} */
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.verifyCredential} */
   async verifyCredential(args: IVerifyCredentialArgs, context: VerifierAgentContext): Promise<IVerifyResult> {
     const credential = args.credential as VerifiableCredential
     if (!credential.proof || !credential.proof.proofValue)
@@ -211,7 +213,7 @@ export class CredentialProviderEIP712 implements ICredentialProvider {
     }
   }
 
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.createVerifiablePresentation} */
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.createVerifiablePresentation} */
   async createVerifiablePresentation(
     args: ICreateVerifiablePresentationArgs,
     context: IssuerAgentContext,
@@ -322,7 +324,7 @@ export class CredentialProviderEIP712 implements ICredentialProvider {
     return presentation as VerifiablePresentation
   }
 
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.verifyPresentation} */
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.verifyPresentation} */
   async verifyPresentation(
     args: IVerifyPresentationArgs,
     context: VerifierAgentContext,

--- a/packages/credential-jwt/src/__tests__/issue-verify-flow-jwt.test.ts
+++ b/packages/credential-jwt/src/__tests__/issue-verify-flow-jwt.test.ts
@@ -74,7 +74,7 @@ describe('credential-jwt full flow', () => {
             }),
           }),
         }),
-        new CredentialPlugin({ issuers: [jwt] }),
+        new CredentialPlugin([jwt]),
       ],
     })
     didKeyIdentifier = await agent.didManagerCreate()

--- a/packages/credential-jwt/src/__tests__/issue-verify-flow-jwt.test.ts
+++ b/packages/credential-jwt/src/__tests__/issue-verify-flow-jwt.test.ts
@@ -14,25 +14,16 @@ import { KeyManager, MemoryKeyStore, MemoryPrivateKeyStore } from '../../../key-
 import { KeyManagementSystem } from '../../../kms-local/src/index.js'
 import { getDidKeyResolver, KeyDIDProvider } from '../../../did-provider-key/src/index.js'
 import { DIDResolverPlugin } from '../../../did-resolver/src/index.js'
-import { EthrDIDProvider } from '../../../did-provider-ethr/src/index.js'
 import { Resolver } from 'did-resolver'
-import { getResolver as ethrDidResolver } from 'ethr-did-resolver'
-import { jest } from '@jest/globals'
 
-import 'cross-fetch/polyfill'
 import { CredentialProviderJWT } from '../agent/CredentialProviderJWT.js'
-import { createGanacheProvider } from '../../../test-react-app/src/test-utils/ganache-provider'
-
-jest.setTimeout(300000)
 
 describe('credential-jwt full flow', () => {
   let didKeyIdentifier: IIdentifier
-  let didEthrIdentifier: IIdentifier
   let agent: TAgent<IResolver & IKeyManager & IDIDManager & ICredentialPlugin>
   const jwt = new CredentialProviderJWT()
 
   beforeAll(async () => {
-    const { provider, registry } = await createGanacheProvider()
     agent = createAgent<IResolver & IKeyManager & IDIDManager & ICredentialPlugin>({
       plugins: [
         new KeyManager({
@@ -44,17 +35,6 @@ describe('credential-jwt full flow', () => {
         new DIDManager({
           providers: {
             'did:key': new KeyDIDProvider({ defaultKms: 'local' }),
-            'did:ethr': new EthrDIDProvider({
-              defaultKms: 'local',
-              networks: [
-                {
-                  chainId: 1337,
-                  name: 'ganache',
-                  provider: provider as any, // different versions of ethers complain about a type mismatch here
-                  registry,
-                },
-              ],
-            }),
           },
           store: new MemoryDIDStore(),
           defaultProvider: 'did:key',
@@ -62,28 +42,17 @@ describe('credential-jwt full flow', () => {
         new DIDResolverPlugin({
           resolver: new Resolver({
             ...getDidKeyResolver(),
-            ...ethrDidResolver({
-              networks: [
-                {
-                  chainId: 1337,
-                  name: 'ganache',
-                  provider: provider as any, // different versions of ethers complain about a type mismatch here
-                  registry,
-                },
-              ],
-            }),
           }),
         }),
         new CredentialPlugin([jwt]),
       ],
     })
     didKeyIdentifier = await agent.didManagerCreate()
-    didEthrIdentifier = await agent.didManagerCreate({ provider: 'did:ethr:ganache' })
   })
 
   it('issues and verifies JWT credential', async () => {
     const credential: CredentialPayload = {
-      issuer: { id: didEthrIdentifier.did },
+      issuer: { id: didKeyIdentifier.did },
       '@context': ['https://www.w3.org/2018/credentials/v1', 'https://example.com/1/2/3'],
       type: ['VerifiableCredential', 'Custom'],
       issuanceDate: new Date().toISOString(),
@@ -108,7 +77,7 @@ describe('credential-jwt full flow', () => {
 
   it('issues credential and verifies presentation', async () => {
     const credential: CredentialPayload = {
-      issuer: { id: didEthrIdentifier.did },
+      issuer: { id: didKeyIdentifier.did },
       '@context': ['https://www.w3.org/2018/credentials/v1', 'https://veramo.io/contexts/profile/v1'],
       type: ['VerifiableCredential', 'Profile'],
       issuanceDate: new Date().toISOString(),
@@ -125,7 +94,7 @@ describe('credential-jwt full flow', () => {
     const verifiablePresentation = await agent.createVerifiablePresentation({
       presentation: {
         verifiableCredential: [verifiableCredential1],
-        holder: didEthrIdentifier.did,
+        holder: didKeyIdentifier.did,
       },
       challenge: 'VERAMO',
       proofFormat: 'jwt',

--- a/packages/credential-jwt/src/agent/CredentialProviderJWT.ts
+++ b/packages/credential-jwt/src/agent/CredentialProviderJWT.ts
@@ -1,20 +1,19 @@
 import {
   CredentialPayload,
+  IAgentContext,
   ICreateVerifiableCredentialArgs,
-  ICanIssueCredentialTypeArgs,
+  ICreateVerifiablePresentationArgs,
   IIdentifier,
   IKey,
+  IKeyManager,
   IssuerAgentContext,
+  IVerifyCredentialArgs,
+  IVerifyPresentationArgs,
+  IVerifyResult,
+  PROOF_FORMAT,
   VerifiableCredential,
   VerifiablePresentation,
-  IAgentContext,
-  IKeyManager,
-  ICreateVerifiablePresentationArgs,
-  IVerifyCredentialArgs,
-  IVerifyResult,
-  IVerifyPresentationArgs,
-  ICanVerifyDocumentTypeArgs,
-  VerifierAgentContext, PROOF_FORMAT,
+  VerifierAgentContext,
 } from '@veramo/core-types'
 import {
   asArray,
@@ -26,7 +25,7 @@ import {
   processEntryToArray,
   removeDIDParameters,
 } from '@veramo/utils'
-import { ICredentialProvider } from '@veramo/credential-w3c'
+import { ICredentialProvider, ProofFormatQuery, TentativeVerificationQuery } from '@veramo/credential-w3c'
 
 import canonicalize from 'canonicalize'
 
@@ -43,12 +42,16 @@ import { Resolvable } from 'did-resolver'
 import { decodeJWT } from 'did-jwt'
 
 import Debug from 'debug'
+
 const debug = Debug('veramo:credential-jwt:agent')
 
 /**
- * A handler that implements the {@link ICredentialProvider} methods.
+ * A Veramo Credential sub-plugin that implements
+ * a {@link @veramo/credential-w3c#ICredentialProvider | ICredentialProvider} with support for
+ * Verifiable Credentials and Presentations with the JWT format.
  *
  * @beta This API may change without a BREAKING CHANGE notice.
+ * @see {@link https://www.w3.org/TR/vc-data-model-1.1/ | VC 1.1 data model}.
  */
 export class CredentialProviderJWT implements ICredentialProvider {
   /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.getProofFormatsSupportedForKey} */
@@ -59,21 +62,21 @@ export class CredentialProviderJWT implements ICredentialProvider {
     return []
   }
 
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.canIssueCredentialType} */
-  async canIssueCredentialType(args: ICanIssueCredentialTypeArgs): Promise<boolean> {
-    return args.proofFormat === PROOF_FORMAT.JWT
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.canIssueCredentialType} */
+  canIssueProofFormat(query: ProofFormatQuery): boolean {
+    return query.proofFormat === PROOF_FORMAT.JWT
   }
 
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.canVerifyDocumentType */
-  canVerifyDocumentType(args: ICanVerifyDocumentTypeArgs): boolean {
-    const { document } = args
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.canVerifyDocumentType} */
+  canVerifyDocumentType(query: TentativeVerificationQuery): boolean {
+    const { document } = query
     return (
       typeof document === 'string' ||
       (typeof document === 'object' && (<VerifiableCredential>document)?.proof?.jwt)
     )
   }
 
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.createVerifiableCredential} */
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.createVerifiableCredential} */
   async createVerifiableCredential(
     args: ICreateVerifiableCredentialArgs,
     context: IssuerAgentContext,
@@ -124,7 +127,7 @@ export class CredentialProviderJWT implements ICredentialProvider {
     return normalizeCredential(jwt)
   }
 
-  /** {@inheritdoc ICredentialVerifier.verifyCredential} */
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.verifyCredential} */
   async verifyCredential(args: IVerifyCredentialArgs, context: VerifierAgentContext): Promise<IVerifyResult> {
     let { credential, policies, ...otherOptions } = args
     let verifiedCredential: VerifiableCredential
@@ -183,7 +186,7 @@ export class CredentialProviderJWT implements ICredentialProvider {
     }
   }
 
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.createVerifiablePresentation} */
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.createVerifiablePresentation} */
   async createVerifiablePresentation(
     args: ICreateVerifiablePresentationArgs,
     context: IssuerAgentContext,
@@ -259,7 +262,7 @@ export class CredentialProviderJWT implements ICredentialProvider {
     return normalizePresentation(jwt)
   }
 
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.verifyPresentation} */
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.verifyPresentation} */
   async verifyPresentation(
     args: IVerifyPresentationArgs,
     context: VerifierAgentContext,
@@ -331,7 +334,7 @@ export class CredentialProviderJWT implements ICredentialProvider {
    * Checks if a key is suitable for signing JWT payloads.
    * @param key - the key to check
    *
-   * @beta
+   * @internal
    */
   matchKeyForJWT(key: IKey): boolean {
     switch (key.type) {
@@ -347,8 +350,7 @@ export class CredentialProviderJWT implements ICredentialProvider {
 
   wrapSigner(context: IAgentContext<Pick<IKeyManager, 'keyManagerSign'>>, key: IKey, algorithm?: string) {
     return async (data: string | Uint8Array): Promise<string> => {
-      const result = await context.agent.keyManagerSign({ keyRef: key.kid, data: <string>data, algorithm })
-      return result
+      return context.agent.keyManagerSign({ keyRef: key.kid, data: <string>data, algorithm })
     }
   }
 }

--- a/packages/credential-jwt/src/agent/CredentialProviderJWT.ts
+++ b/packages/credential-jwt/src/agent/CredentialProviderJWT.ts
@@ -1,6 +1,5 @@
 import {
   CredentialPayload,
-  IAgentPlugin,
   ICreateVerifiableCredentialArgs,
   ICanIssueCredentialTypeArgs,
   IIdentifier,
@@ -15,7 +14,7 @@ import {
   IVerifyResult,
   IVerifyPresentationArgs,
   ICanVerifyDocumentTypeArgs,
-  VerifierAgentContext,
+  VerifierAgentContext, PROOF_FORMAT,
 } from '@veramo/core-types'
 import {
   asArray,
@@ -27,7 +26,7 @@ import {
   processEntryToArray,
   removeDIDParameters,
 } from '@veramo/utils'
-import { AbstractCredentialProvider } from '@veramo/credential-w3c'
+import { ICredentialProvider } from '@veramo/credential-w3c'
 
 import canonicalize from 'canonicalize'
 
@@ -47,31 +46,31 @@ import Debug from 'debug'
 const debug = Debug('veramo:credential-jwt:agent')
 
 /**
- * A handler that implements the {@link AbstractCredentialProvider} methods.
+ * A handler that implements the {@link ICredentialProvider} methods.
  *
  * @beta This API may change without a BREAKING CHANGE notice.
  */
-export class CredentialProviderJWT implements AbstractCredentialProvider {
-
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.matchKeyForType} */
-  matchKeyForType(key: IKey): boolean {
-    return this.matchKeyForJWT(key)
-  }
-
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.getTypeProofFormat} */
-  getTypeProofFormat(): string {
-    return 'jwt'
+export class CredentialProviderJWT implements ICredentialProvider {
+  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.getProofFormatsSupportedForKey} */
+  getProofFormatsSupportedForKey(key: IKey): string[] {
+    if (this.matchKeyForJWT(key)) {
+      return [PROOF_FORMAT.JWT]
+    }
+    return []
   }
 
   /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.canIssueCredentialType} */
-  canIssueCredentialType(args: ICanIssueCredentialTypeArgs): boolean {
-    return args.proofFormat === 'jwt'
+  async canIssueCredentialType(args: ICanIssueCredentialTypeArgs): Promise<boolean> {
+    return args.proofFormat === PROOF_FORMAT.JWT
   }
 
   /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.canVerifyDocumentType */
   canVerifyDocumentType(args: ICanVerifyDocumentTypeArgs): boolean {
     const { document } = args
-    return typeof document === 'string' || (<VerifiableCredential>document)?.proof?.jwt
+    return (
+      typeof document === 'string' ||
+      (typeof document === 'object' && (<VerifiableCredential>document)?.proof?.jwt)
+    )
   }
 
   /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.createVerifiableCredential} */
@@ -126,10 +125,7 @@ export class CredentialProviderJWT implements AbstractCredentialProvider {
   }
 
   /** {@inheritdoc ICredentialVerifier.verifyCredential} */
-  async verifyCredential(
-    args: IVerifyCredentialArgs,
-    context: VerifierAgentContext,
-  ): Promise<IVerifyResult> {
+  async verifyCredential(args: IVerifyCredentialArgs, context: VerifierAgentContext): Promise<IVerifyResult> {
     let { credential, policies, ...otherOptions } = args
     let verifiedCredential: VerifiableCredential
     let verificationResult: IVerifyResult | undefined = { verified: false }
@@ -334,7 +330,6 @@ export class CredentialProviderJWT implements AbstractCredentialProvider {
   /**
    * Checks if a key is suitable for signing JWT payloads.
    * @param key - the key to check
-   * @param context - the Veramo agent context, unused here
    *
    * @beta
    */
@@ -350,15 +345,10 @@ export class CredentialProviderJWT implements AbstractCredentialProvider {
     }
   }
 
-  wrapSigner(
-    context: IAgentContext<Pick<IKeyManager, 'keyManagerSign'>>,
-    key: IKey,
-    algorithm?: string,
-  ) {
+  wrapSigner(context: IAgentContext<Pick<IKeyManager, 'keyManagerSign'>>, key: IKey, algorithm?: string) {
     return async (data: string | Uint8Array): Promise<string> => {
       const result = await context.agent.keyManagerSign({ keyRef: key.kid, data: <string>data, algorithm })
       return result
     }
   }
 }
-

--- a/packages/credential-jwt/src/agent/CredentialProviderJWT.ts
+++ b/packages/credential-jwt/src/agent/CredentialProviderJWT.ts
@@ -11,6 +11,7 @@ import {
   IVerifyPresentationArgs,
   IVerifyResult,
   PROOF_FORMAT,
+  ProofFormat,
   VerifiableCredential,
   VerifiablePresentation,
   VerifierAgentContext,
@@ -55,7 +56,7 @@ const debug = Debug('veramo:credential-jwt:agent')
  */
 export class CredentialProviderJWT implements ICredentialProvider {
   /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.getProofFormatsSupportedForKey} */
-  getProofFormatsSupportedForKey(key: IKey): string[] {
+  getProofFormatsSupportedForKey(key: IKey): ProofFormat[] {
     if (this.matchKeyForJWT(key)) {
       return [PROOF_FORMAT.JWT]
     }

--- a/packages/credential-ld/src/CredentialProviderLD.ts
+++ b/packages/credential-ld/src/CredentialProviderLD.ts
@@ -1,8 +1,6 @@
 import {
   CredentialPayload,
   IAgentContext,
-  ICanIssueCredentialTypeArgs,
-  ICanVerifyDocumentTypeArgs,
   ICreateVerifiableCredentialArgs,
   ICreateVerifiablePresentationArgs,
   IIdentifier,
@@ -39,14 +37,17 @@ import { LdSuiteLoader } from './ld-suite-loader.js'
 import { ContextDoc } from './types.js'
 import { DIDResolutionOptions } from 'did-resolver'
 
-import { ICredentialProvider } from '@veramo/credential-w3c'
+import { ICredentialProvider, ProofFormatQuery, TentativeVerificationQuery } from '@veramo/credential-w3c'
 
 const debug = Debug('veramo:credential-ld:action-handler')
 
 /**
- * A handler that implements the {@link ICredentialProvider} methods.
+ * A Veramo Credential sub-plugin that implements
+ * a {@link @veramo/credential-w3c#ICredentialProvider | ICredentialProvider} with support for
+ * Verifiable Credentials and Presentations using JSON-LD proofs.
  *
- * @public
+ * @beta This API may change without a BREAKING CHANGE notice.
+ * @see {@link https://www.w3.org/TR/vc-data-model-1.1/ | VC 1.1 data model}.
  */
 export class CredentialProviderLD implements ICredentialProvider {
   private ldCredentialModule: LdCredentialModule
@@ -58,7 +59,7 @@ export class CredentialProviderLD implements ICredentialProvider {
     })
   }
 
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.getProofFormatsSupportedForKey} */
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.getProofFormatsSupportedForKey} */
   getProofFormatsSupportedForKey(key: IKey): string[] {
     if (this.matchKeyForLDSuite(key)) {
       return [PROOF_FORMAT.LD_SIGNATURE]
@@ -66,14 +67,14 @@ export class CredentialProviderLD implements ICredentialProvider {
     return []
   }
 
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.canIssueCredentialType} */
-  async canIssueCredentialType(args: ICanIssueCredentialTypeArgs): Promise<boolean> {
-    return args.proofFormat === PROOF_FORMAT.LD_SIGNATURE
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.canIssueCredentialType} */
+  canIssueProofFormat(query: ProofFormatQuery): boolean {
+    return query.proofFormat === PROOF_FORMAT.LD_SIGNATURE
   }
 
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.canVerifyDocumentType */
-  canVerifyDocumentType(args: ICanVerifyDocumentTypeArgs): boolean {
-    const { document } = args
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.canVerifyDocumentType} */
+  canVerifyDocumentType(query: TentativeVerificationQuery): boolean {
+    const { document } = query
 
     for (const suite of this.ldCredentialModule.ldSuiteLoader.getAllSignatureSuites()) {
       if (suite.getSupportedProofType() === (<VerifiableCredential>document)?.proof?.type || '') {
@@ -84,7 +85,7 @@ export class CredentialProviderLD implements ICredentialProvider {
     return false
   }
 
-  /** {@inheritdoc ICredentialIssuer.createVerifiablePresentationLD} */
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.createVerifiablePresentation} */
   async createVerifiablePresentation(
     args: ICreateVerifiablePresentationArgs,
     context: IssuerAgentContext,
@@ -155,7 +156,7 @@ export class CredentialProviderLD implements ICredentialProvider {
     }
   }
 
-  /** {@inheritdoc ICredentialIssuer.createVerifiableCredentialLD} */
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.createVerifiableCredential} */
   async createVerifiableCredential(
     args: ICreateVerifiableCredentialArgs,
     context: IssuerAgentContext,
@@ -209,7 +210,7 @@ export class CredentialProviderLD implements ICredentialProvider {
     }
   }
 
-  /** {@inheritdoc ICredentialIssuer.verifyCredentialLD} */
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.verifyCredential} */
   async verifyCredential(args: IVerifyCredentialArgs, context: VerifierAgentContext): Promise<IVerifyResult> {
     args.credential = args.credential as VerifiableCredential
     const credential = args.credential
@@ -223,7 +224,7 @@ export class CredentialProviderLD implements ICredentialProvider {
     return this.ldCredentialModule.verifyCredential(credential, { ...args, now }, context)
   }
 
-  /** {@inheritdoc ICredentialVerifier.verifyPresentation} */
+  /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.verifyPresentation} */
   async verifyPresentation(
     args: IVerifyPresentationArgs,
     context: VerifierAgentContext,
@@ -248,7 +249,7 @@ export class CredentialProviderLD implements ICredentialProvider {
    *
    * @internal
    */
-  matchKeyForLDSuite(k: IKey): boolean {
+  private matchKeyForLDSuite(k: IKey): boolean {
     // prefilter based on key algorithms
     switch (k.type) {
       case 'Ed25519':

--- a/packages/credential-ld/src/CredentialProviderLD.ts
+++ b/packages/credential-ld/src/CredentialProviderLD.ts
@@ -1,8 +1,8 @@
 import {
   CredentialPayload,
   IAgentContext,
-  IAgentPlugin,
   ICanIssueCredentialTypeArgs,
+  ICanVerifyDocumentTypeArgs,
   ICreateVerifiableCredentialArgs,
   ICreateVerifiablePresentationArgs,
   IIdentifier,
@@ -13,10 +13,10 @@ import {
   IVerifyPresentationArgs,
   IVerifyResult,
   PresentationPayload,
+  PROOF_FORMAT,
   VerifiableCredential,
   VerifiablePresentation,
   VerifierAgentContext,
-  ICanVerifyDocumentTypeArgs,
 } from '@veramo/core-types'
 import { VeramoLdSignature } from './index.js'
 import Debug from 'debug'
@@ -36,22 +36,19 @@ import {
 
 import { LdCredentialModule } from './ld-credential-module.js'
 import { LdSuiteLoader } from './ld-suite-loader.js'
-import {
-  ContextDoc,
-} from './types.js'
+import { ContextDoc } from './types.js'
 import { DIDResolutionOptions } from 'did-resolver'
 
-import { AbstractCredentialProvider } from '@veramo/credential-w3c'
+import { ICredentialProvider } from '@veramo/credential-w3c'
 
 const debug = Debug('veramo:credential-ld:action-handler')
 
 /**
- * A handler that implements the {@link AbstractCredentialProvider} methods.
+ * A handler that implements the {@link ICredentialProvider} methods.
  *
  * @public
  */
-export class CredentialProviderLD implements AbstractCredentialProvider {
-
+export class CredentialProviderLD implements ICredentialProvider {
   private ldCredentialModule: LdCredentialModule
 
   constructor(options: { contextMaps: RecordLike<OrPromise<ContextDoc>>[]; suites: VeramoLdSignature[] }) {
@@ -61,19 +58,17 @@ export class CredentialProviderLD implements AbstractCredentialProvider {
     })
   }
 
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.matchKeyForType} */
-  matchKeyForType(key: IKey): boolean {
-    return this.matchKeyForLDSuite(key)
-  }
-
-  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.getTypeProofFormat} */
-  getTypeProofFormat(): string {
-    return 'lds'
+  /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.getProofFormatsSupportedForKey} */
+  getProofFormatsSupportedForKey(key: IKey): string[] {
+    if (this.matchKeyForLDSuite(key)) {
+      return [PROOF_FORMAT.LD_SIGNATURE]
+    }
+    return []
   }
 
   /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.canIssueCredentialType} */
-  canIssueCredentialType(args: ICanIssueCredentialTypeArgs): boolean {
-    return (args.proofFormat === 'lds')
+  async canIssueCredentialType(args: ICanIssueCredentialTypeArgs): Promise<boolean> {
+    return args.proofFormat === PROOF_FORMAT.LD_SIGNATURE
   }
 
   /** {@inheritdoc @veramo/credential-w3c#AbstractCredentialProvider.canVerifyDocumentType */
@@ -111,14 +106,13 @@ export class CredentialProviderLD implements AbstractCredentialProvider {
     }
 
     if (args.presentation.verifiableCredential) {
-      const credentials = args.presentation.verifiableCredential.map((cred) => {
+      presentation.verifiableCredential = args.presentation.verifiableCredential.map((cred) => {
         if (typeof cred !== 'string' && cred.proof.jwt) {
           return cred.proof.jwt
         } else {
           return cred
         }
       })
-      presentation.verifiableCredential = credentials
     }
 
     //issuanceDate must not be present for presentations because it is not defined in a @context
@@ -248,6 +242,30 @@ export class CredentialProviderLD implements AbstractCredentialProvider {
     )
   }
 
+  /**
+   * Returns true if the key is supported by any of the installed LD Signature suites
+   * @param k - the key to match
+   *
+   * @internal
+   */
+  matchKeyForLDSuite(k: IKey): boolean {
+    // prefilter based on key algorithms
+    switch (k.type) {
+      case 'Ed25519':
+        if (!k.meta?.algorithms?.includes('EdDSA')) return false
+        break
+      case 'Secp256k1':
+        if (intersect(k.meta?.algorithms ?? [], ['ES256K-R', 'ES256K']).length == 0) return false
+        break
+    }
+
+    // TODO: this should return a list of supported suites, not just a boolean
+    const suites = this.ldCredentialModule.ldSuiteLoader.getAllSignatureSuites()
+    return suites
+      .map((suite: VeramoLdSignature) => suite.getSupportedVeramoKeyType().includes(k.type))
+      .some((supportsThisKey: boolean) => supportsThisKey)
+  }
+
   private async findSigningKeyWithId(
     context: IAgentContext<IResolver>,
     identifier: IIdentifier,
@@ -284,29 +302,5 @@ export class CredentialProviderLD implements AbstractCredentialProvider {
     if (!signingKey) throw Error(`key_not_found: No suitable signing key found for ${identifier.did}`)
     verificationMethodId = signingKey.meta.verificationMethod.id
     return { signingKey, verificationMethodId }
-  }
-
-  /**
-   * Returns true if the key is supported by any of the installed LD Signature suites
-   * @param k - the key to match
-   *
-   * @internal
-   */
-  matchKeyForLDSuite(k: IKey): boolean {
-    // prefilter based on key algorithms
-    switch (k.type) {
-      case 'Ed25519':
-        if (!k.meta?.algorithms?.includes('EdDSA')) return false
-        break
-      case 'Secp256k1':
-        if (intersect(k.meta?.algorithms ?? [], ['ES256K-R', 'ES256K']).length == 0) return false
-        break
-    }
-
-    // TODO: this should return a list of supported suites, not just a boolean
-    const suites = this.ldCredentialModule.ldSuiteLoader.getAllSignatureSuites()
-    return suites
-      .map((suite: VeramoLdSignature) => suite.getSupportedVeramoKeyType().includes(k.type))
-      .some((supportsThisKey: boolean) => supportsThisKey)
   }
 }

--- a/packages/credential-ld/src/CredentialProviderLD.ts
+++ b/packages/credential-ld/src/CredentialProviderLD.ts
@@ -12,6 +12,7 @@ import {
   IVerifyResult,
   PresentationPayload,
   PROOF_FORMAT,
+  ProofFormat,
   VerifiableCredential,
   VerifiablePresentation,
   VerifierAgentContext,
@@ -60,7 +61,7 @@ export class CredentialProviderLD implements ICredentialProvider {
   }
 
   /** {@inheritdoc @veramo/credential-w3c#ICredentialProvider.getProofFormatsSupportedForKey} */
-  getProofFormatsSupportedForKey(key: IKey): string[] {
+  getProofFormatsSupportedForKey(key: IKey): ProofFormat[] {
     if (this.matchKeyForLDSuite(key)) {
       return [PROOF_FORMAT.LD_SIGNATURE]
     }

--- a/packages/credential-ld/src/__tests__/issue-verify-ed25519-2020.test.ts
+++ b/packages/credential-ld/src/__tests__/issue-verify-ed25519-2020.test.ts
@@ -60,7 +60,7 @@ describe('credential-LD full flow', () => {
             ...new FakeDidResolver(() => agent, true).getDidFakeResolver(),
           }),
         }),
-        new CredentialPlugin({ issuers: [ld] }),
+        new CredentialPlugin([ld]),
       ],
     })
     didFakeIdentifier = await agent.didManagerImport({

--- a/packages/credential-ld/src/__tests__/issue-verify-flow-ld.test.ts
+++ b/packages/credential-ld/src/__tests__/issue-verify-flow-ld.test.ts
@@ -149,6 +149,7 @@ describe('credential-LD full flow', () => {
 
   it('works with EcdsaSecp256k1RecoveryMethod2020 credentials', async () => {
     const credential: CredentialPayload = {
+      // use did:ethr issuer to have a EcdsaSecp256k1RecoveryMethod2020 as a verification method in the DID document
       issuer: didEthrIdentifier.did,
       '@context': ['custom:example.context'],
       credentialSubject: {
@@ -161,6 +162,7 @@ describe('credential-LD full flow', () => {
     })
 
     expect(verifiableCredential).toBeDefined()
+    expect((verifiableCredential as any).proof.type).toBe('EcdsaSecp256k1RecoverySignature2020')
 
     const result = await agent.verifyCredential({
       credential: verifiableCredential,

--- a/packages/credential-ld/src/__tests__/issue-verify-flow-ld.test.ts
+++ b/packages/credential-ld/src/__tests__/issue-verify-flow-ld.test.ts
@@ -78,17 +78,19 @@ describe('credential-LD full flow', () => {
         new DIDResolverPlugin({
           resolver: new Resolver({
             ...getDidKeyResolver(),
-            ...ethrDidResolver({ networks: [
+            ...ethrDidResolver({
+              networks: [
                 {
                   chainId: 1337,
                   name: 'ganache',
                   provider,
                   registry,
                 },
-              ], }),
+              ],
+            }),
           }),
         }),
-        new CredentialPlugin({ issuers: [ld] }),
+        new CredentialPlugin([ld]),
       ],
     })
     didKeyIdentifier = await agent.didManagerCreate()

--- a/packages/credential-w3c/src/__tests__/action-handler.test.ts
+++ b/packages/credential-w3c/src/__tests__/action-handler.test.ts
@@ -1,8 +1,11 @@
 import {
   CredentialPayload,
+  ICanIssueCredentialTypeArgs,
+  ICanVerifyDocumentTypeArgs,
   ICredentialPlugin,
   IDIDManager,
   IIdentifier,
+  IKey,
   IKeyManager,
   IResolver,
   PresentationPayload,
@@ -18,13 +21,24 @@ import { DIDManager, MemoryDIDStore } from '../../../did-manager/src'
 import { getDidKeyResolver, KeyDIDProvider } from '../../../did-provider-key/src'
 import { DIDResolverPlugin } from '../../../did-resolver/src'
 import { Resolver } from 'did-resolver'
+import { ICredentialProvider } from '../abstract-credential-provider'
+import {
+  ICreateVerifiableCredentialArgs,
+  ICreateVerifiablePresentationArgs,
+  IssuerAgentContext,
+  IVerifyCredentialArgs,
+  IVerifyPresentationArgs,
+  IVerifyResult,
+  VerifiableCredential,
+  VerifiablePresentation,
+  VerifierAgentContext,
+} from '@veramo/core-types'
 
 let didKeyIdentifier: IIdentifier
 let agent: TAgent<IResolver & IKeyManager & IDIDManager & ICredentialPlugin>
 
 describe('@veramo/credential-w3c', () => {
   beforeAll(async () => {
-    const jwt = new CredentialProviderJWT()
     agent = createAgent<IResolver & IKeyManager & IDIDManager & ICredentialPlugin>({
       plugins: [
         new KeyManager({
@@ -45,13 +59,58 @@ describe('@veramo/credential-w3c', () => {
             ...getDidKeyResolver(),
           }),
         }),
-        new CredentialPlugin([jwt]),
+        new CredentialPlugin([new CredentialProviderJWT()]),
       ],
     })
     didKeyIdentifier = await agent.didManagerCreate()
   })
 
-  test('handles createVerifiableCredential', async () => {
+  class DummyProofProvider implements ICredentialProvider {
+    createVerifiableCredential(
+      args: ICreateVerifiableCredentialArgs,
+      context: IssuerAgentContext,
+    ): Promise<VerifiableCredential> {
+      throw new Error('Method not implemented.')
+    }
+    createVerifiablePresentation(
+      args: ICreateVerifiablePresentationArgs,
+      context: IssuerAgentContext,
+    ): Promise<VerifiablePresentation> {
+      throw new Error('Method not implemented.')
+    }
+    verifyCredential(args: IVerifyCredentialArgs, context: VerifierAgentContext): Promise<IVerifyResult> {
+      throw new Error('Method not implemented.')
+    }
+    verifyPresentation(args: IVerifyPresentationArgs, context: VerifierAgentContext): Promise<IVerifyResult> {
+      throw new Error('Method not implemented.')
+    }
+    canVerifyDocumentType(args: ICanVerifyDocumentTypeArgs): boolean {
+      return false
+    }
+
+    getProofFormatsSupportedForKey(key: IKey): string[] {
+      return ['dummy', 'proofs']
+    }
+
+    async canIssueCredentialType(args: ICanIssueCredentialTypeArgs): Promise<boolean> {
+      return false
+    }
+  }
+
+  it('lists usable proof formats', async () => {
+    expect.assertions(2)
+
+    const proofFormats = await agent.listUsableProofFormats(didKeyIdentifier)
+    expect(proofFormats).toEqual(['jwt'])
+
+    const newAgent = createAgent<ICredentialPlugin>({
+      plugins: [new CredentialPlugin([new DummyProofProvider()])],
+    })
+    const proofFormats2 = await newAgent.listUsableProofFormats(didKeyIdentifier)
+    expect(proofFormats2).toEqual(['dummy', 'proofs'])
+  })
+
+  it('handles createVerifiableCredential', async () => {
     expect.assertions(1)
 
     const issuerId = didKeyIdentifier.did
@@ -81,7 +140,7 @@ describe('@veramo/credential-w3c', () => {
     expect(vc.id).toEqual('vc1')
   })
 
-  test('handles createVerifiablePresentation', async () => {
+  it('handles createVerifiablePresentation', async () => {
     expect.assertions(1)
 
     const issuerId = didKeyIdentifier.did
@@ -122,5 +181,25 @@ describe('@veramo/credential-w3c', () => {
     })
 
     expect(vp.holder).toEqual(issuerId)
+  })
+
+  it('fails to create credential with unknown proof format', async () => {
+    expect.assertions(1)
+    await expect(() =>
+      agent.createVerifiableCredential({
+        credential: { dummy: 'data', issuer: { id: didKeyIdentifier.did } },
+        proofFormat: 'unknown',
+      }),
+    ).rejects.toThrow(/invalid_setup: No issuer found for the requested proof format/)
+  })
+
+  it('fails to create presentation with unknown proof format', async () => {
+    expect.assertions(1)
+    await expect(() =>
+      agent.createVerifiablePresentation({
+        presentation: { dummy: 'data', holder: didKeyIdentifier.did },
+        proofFormat: 'unknown',
+      }),
+    ).rejects.toThrow(/invalid_setup: No issuer found for the requested proof format/)
   })
 })

--- a/packages/credential-w3c/src/__tests__/action-handler.test.ts
+++ b/packages/credential-w3c/src/__tests__/action-handler.test.ts
@@ -19,7 +19,6 @@ import { getDidKeyResolver, KeyDIDProvider } from '../../../did-provider-key/src
 import { DIDResolverPlugin } from '../../../did-resolver/src'
 import { Resolver } from 'did-resolver'
 
-
 let didKeyIdentifier: IIdentifier
 let agent: TAgent<IResolver & IKeyManager & IDIDManager & ICredentialPlugin>
 
@@ -46,7 +45,7 @@ describe('@veramo/credential-w3c', () => {
             ...getDidKeyResolver(),
           }),
         }),
-        new CredentialPlugin({ issuers: [jwt] }),
+        new CredentialPlugin([jwt]),
       ],
     })
     didKeyIdentifier = await agent.didManagerCreate()

--- a/packages/credential-w3c/src/__tests__/action-handler.test.ts
+++ b/packages/credential-w3c/src/__tests__/action-handler.test.ts
@@ -1,7 +1,5 @@
 import {
   CredentialPayload,
-  ICanIssueCredentialTypeArgs,
-  ICanVerifyDocumentTypeArgs,
   ICredentialPlugin,
   IDIDManager,
   IIdentifier,
@@ -21,7 +19,11 @@ import { DIDManager, MemoryDIDStore } from '../../../did-manager/src'
 import { getDidKeyResolver, KeyDIDProvider } from '../../../did-provider-key/src'
 import { DIDResolverPlugin } from '../../../did-resolver/src'
 import { Resolver } from 'did-resolver'
-import { ICredentialProvider } from '../abstract-credential-provider'
+import {
+  ICredentialProvider,
+  ProofFormatQuery,
+  TentativeVerificationQuery,
+} from '../abstract-credential-provider'
 import {
   ICreateVerifiableCredentialArgs,
   ICreateVerifiablePresentationArgs,
@@ -84,7 +86,7 @@ describe('@veramo/credential-w3c', () => {
     verifyPresentation(args: IVerifyPresentationArgs, context: VerifierAgentContext): Promise<IVerifyResult> {
       throw new Error('Method not implemented.')
     }
-    canVerifyDocumentType(args: ICanVerifyDocumentTypeArgs): boolean {
+    canVerifyDocumentType(query: TentativeVerificationQuery): boolean {
       return false
     }
 
@@ -92,7 +94,7 @@ describe('@veramo/credential-w3c', () => {
       return ['dummy', 'proofs']
     }
 
-    async canIssueCredentialType(args: ICanIssueCredentialTypeArgs): Promise<boolean> {
+    canIssueProofFormat(query: ProofFormatQuery): boolean {
       return false
     }
   }

--- a/packages/credential-w3c/src/__tests__/issue-verify-flow-w3c.test.ts
+++ b/packages/credential-w3c/src/__tests__/issue-verify-flow-w3c.test.ts
@@ -227,7 +227,6 @@ describe('credential-w3c full flow', () => {
         issuanceDate: false,
       },
     })
-    console.log(response)
 
     expect(response.verified).toBe(true)
   })

--- a/packages/credential-w3c/src/__tests__/issue-verify-flow-w3c.test.ts
+++ b/packages/credential-w3c/src/__tests__/issue-verify-flow-w3c.test.ts
@@ -9,7 +9,7 @@ import {
   VerifiableCredential,
 } from '../../../core-types/src'
 import { createAgent } from '../../../core/src'
-import { CredentialIssuer } from '..'
+import { CredentialPlugin } from '..'
 import { DIDManager, MemoryDIDStore } from '../../../did-manager/src'
 import { KeyManager, MemoryKeyStore, MemoryPrivateKeyStore } from '../../../key-manager/src'
 import { KeyManagementSystem } from '../../../kms-local/src'
@@ -67,7 +67,7 @@ describe('credential-w3c full flow', () => {
             ...getDidKeyResolver(),
           }),
         }),
-        new CredentialIssuer([jwt, ld]),
+        new CredentialPlugin([jwt, ld]),
       ],
     })
     didKeyIdentifier = await agent.didManagerCreate()
@@ -216,29 +216,33 @@ describe('credential-w3c full flow', () => {
    * These tests can be uncommented out when the did-jwt starts to support the policies merge request
    */
 
-  // it('passes the verification of an expired credential with policy exp false',async () => {
-  //   const presentationJWT = 'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJ2cCI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVQcmVzZW50YXRpb24iXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlsiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNklrcFhWQ0o5LmV5SjJZeUk2ZXlKQVkyOXVkR1Y0ZENJNld5Sm9kSFJ3Y3pvdkwzZDNkeTUzTXk1dmNtY3ZNakF4T0M5amNtVmtaVzUwYVdGc2N5OTJNU0lzSW1OMWMzUnZiVHBsZUdGdGNHeGxMbU52Ym5SbGVIUWlYU3dpZEhsd1pTSTZXeUpXWlhKcFptbGhZbXhsUTNKbFpHVnVkR2xoYkNKZExDSmpjbVZrWlc1MGFXRnNVM1ZpYW1WamRDSTZleUp1YjNSb2FXNW5Jam9pWld4elpTQnRZWFIwWlhKekluMTlMQ0p1WW1ZaU9qRXhOall3TWprNE5UZzRMQ0pwYzNNaU9pSmthV1E2YTJWNU9ubzJUV3QyYlhCeFRXbDFOM2h1U25kVE9YQkVSR0ZSYW1oQ1dUWndlbU00V1RKQ2FWRnhSWFUwZW1GRldFMVdUQ0o5LnA4Y2FTS1pTcGdISm1TRzhMekpnSWlWMzFRU3NjOEJ2anZuQ1JrOEM3X1UxLXV5cS11MHlQcDdjRWlSOUtXTnprN2RDQlBiR2pBRGRiNC0tV3V5LUNRIl19LCJuYmYiOjI2NjAyOTg1ODgsImlzcyI6ImRpZDprZXk6ejZNa3ZtcHFNaXU3eG5Kd1M5cEREYVFqaEJZNnB6YzhZMkJpUXFFdTR6YUVYTVZMIiwibm9uY2UiOiJWRVJBTU8ifQ.F-uiI2iVMcdm1VFzkXgtZqq8QGw5XnyEI36vGblBluHnklnNYNmE5eluQ23dbcduGWSe3ZJJ65C7HrPTUoXvDA'
-  //
-  //   const response = await agent.verifyPresentation({
-  //     presentation: presentationJWT,
-  //     policies: {
-  //       exp: false
-  //     }
-  //   })
-  //
-  //   expect(response.verified).toBe(true)
-  // })
-  //
-  // it('passes the verification with nbf in the future with policy nbf false',async () => {
-  //   const presentationJWT = 'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJ2cCI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVQcmVzZW50YXRpb24iXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlsiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNklrcFhWQ0o5LmV5SjJZeUk2ZXlKQVkyOXVkR1Y0ZENJNld5Sm9kSFJ3Y3pvdkwzZDNkeTUzTXk1dmNtY3ZNakF4T0M5amNtVmtaVzUwYVdGc2N5OTJNU0lzSW1OMWMzUnZiVHBsZUdGdGNHeGxMbU52Ym5SbGVIUWlYU3dpZEhsd1pTSTZXeUpXWlhKcFptbGhZbXhsUTNKbFpHVnVkR2xoYkNKZExDSmpjbVZrWlc1MGFXRnNVM1ZpYW1WamRDSTZleUp1YjNSb2FXNW5Jam9pWld4elpTQnRZWFIwWlhKekluMTlMQ0p1WW1ZaU9qRXhOall3TWprNE5UZzRMQ0pwYzNNaU9pSmthV1E2YTJWNU9ubzJUV3QyYlhCeFRXbDFOM2h1U25kVE9YQkVSR0ZSYW1oQ1dUWndlbU00V1RKQ2FWRnhSWFUwZW1GRldFMVdUQ0o5LnA4Y2FTS1pTcGdISm1TRzhMekpnSWlWMzFRU3NjOEJ2anZuQ1JrOEM3X1UxLXV5cS11MHlQcDdjRWlSOUtXTnprN2RDQlBiR2pBRGRiNC0tV3V5LUNRIl19LCJuYmYiOjI2NjAyOTg1ODgsImlzcyI6ImRpZDprZXk6ejZNa3ZtcHFNaXU3eG5Kd1M5cEREYVFqaEJZNnB6YzhZMkJpUXFFdTR6YUVYTVZMIiwibm9uY2UiOiJWRVJBTU8ifQ.F-uiI2iVMcdm1VFzkXgtZqq8QGw5XnyEI36vGblBluHnklnNYNmE5eluQ23dbcduGWSe3ZJJ65C7HrPTUoXvDA'
-  //
-  //   const response = await agent.verifyPresentation({
-  //     presentation: presentationJWT,
-  //     policies: {
-  //       nbf: false
-  //     }
-  //   })
-  //
-  //   expect(response.verified).toBe(true)
-  // })
+  it('passes the verification of an expired credential with policy exp false', async () => {
+    const presentationJWT =
+      'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJ2cCI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVQcmVzZW50YXRpb24iXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlsiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNklrcFhWQ0o5LmV5SjJZeUk2ZXlKQVkyOXVkR1Y0ZENJNld5Sm9kSFJ3Y3pvdkwzZDNkeTUzTXk1dmNtY3ZNakF4T0M5amNtVmtaVzUwYVdGc2N5OTJNU0lzSW1OMWMzUnZiVHBsZUdGdGNHeGxMbU52Ym5SbGVIUWlYU3dpZEhsd1pTSTZXeUpXWlhKcFptbGhZbXhsUTNKbFpHVnVkR2xoYkNKZExDSmpjbVZrWlc1MGFXRnNVM1ZpYW1WamRDSTZleUp1YjNSb2FXNW5Jam9pWld4elpTQnRZWFIwWlhKekluMTlMQ0p1WW1ZaU9qRXhOall3TWprNE5UZzRMQ0pwYzNNaU9pSmthV1E2YTJWNU9ubzJUV3QyYlhCeFRXbDFOM2h1U25kVE9YQkVSR0ZSYW1oQ1dUWndlbU00V1RKQ2FWRnhSWFUwZW1GRldFMVdUQ0o5LnA4Y2FTS1pTcGdISm1TRzhMekpnSWlWMzFRU3NjOEJ2anZuQ1JrOEM3X1UxLXV5cS11MHlQcDdjRWlSOUtXTnprN2RDQlBiR2pBRGRiNC0tV3V5LUNRIl19LCJuYmYiOjI2NjAyOTg1ODgsImlzcyI6ImRpZDprZXk6ejZNa3ZtcHFNaXU3eG5Kd1M5cEREYVFqaEJZNnB6YzhZMkJpUXFFdTR6YUVYTVZMIiwibm9uY2UiOiJWRVJBTU8ifQ.F-uiI2iVMcdm1VFzkXgtZqq8QGw5XnyEI36vGblBluHnklnNYNmE5eluQ23dbcduGWSe3ZJJ65C7HrPTUoXvDA'
+
+    const response = await agent.verifyPresentation({
+      presentation: presentationJWT,
+      policies: {
+        expirationDate: false,
+        issuanceDate: false,
+      },
+    })
+    console.log(response)
+
+    expect(response.verified).toBe(true)
+  })
+
+  it('passes the verification with nbf in the future with policy nbf false', async () => {
+    const presentationJWT =
+      'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJ2cCI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVQcmVzZW50YXRpb24iXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlsiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNklrcFhWQ0o5LmV5SjJZeUk2ZXlKQVkyOXVkR1Y0ZENJNld5Sm9kSFJ3Y3pvdkwzZDNkeTUzTXk1dmNtY3ZNakF4T0M5amNtVmtaVzUwYVdGc2N5OTJNU0lzSW1OMWMzUnZiVHBsZUdGdGNHeGxMbU52Ym5SbGVIUWlYU3dpZEhsd1pTSTZXeUpXWlhKcFptbGhZbXhsUTNKbFpHVnVkR2xoYkNKZExDSmpjbVZrWlc1MGFXRnNVM1ZpYW1WamRDSTZleUp1YjNSb2FXNW5Jam9pWld4elpTQnRZWFIwWlhKekluMTlMQ0p1WW1ZaU9qRXhOall3TWprNE5UZzRMQ0pwYzNNaU9pSmthV1E2YTJWNU9ubzJUV3QyYlhCeFRXbDFOM2h1U25kVE9YQkVSR0ZSYW1oQ1dUWndlbU00V1RKQ2FWRnhSWFUwZW1GRldFMVdUQ0o5LnA4Y2FTS1pTcGdISm1TRzhMekpnSWlWMzFRU3NjOEJ2anZuQ1JrOEM3X1UxLXV5cS11MHlQcDdjRWlSOUtXTnprN2RDQlBiR2pBRGRiNC0tV3V5LUNRIl19LCJuYmYiOjI2NjAyOTg1ODgsImlzcyI6ImRpZDprZXk6ejZNa3ZtcHFNaXU3eG5Kd1M5cEREYVFqaEJZNnB6YzhZMkJpUXFFdTR6YUVYTVZMIiwibm9uY2UiOiJWRVJBTU8ifQ.F-uiI2iVMcdm1VFzkXgtZqq8QGw5XnyEI36vGblBluHnklnNYNmE5eluQ23dbcduGWSe3ZJJ65C7HrPTUoXvDA'
+
+    const response = await agent.verifyPresentation({
+      presentation: presentationJWT,
+      policies: {
+        issuanceDate: false,
+      },
+    })
+
+    expect(response.verified).toBe(true)
+  })
 })

--- a/packages/credential-w3c/src/__tests__/issue-verify-flow-w3c.test.ts
+++ b/packages/credential-w3c/src/__tests__/issue-verify-flow-w3c.test.ts
@@ -67,7 +67,7 @@ describe('credential-w3c full flow', () => {
             ...getDidKeyResolver(),
           }),
         }),
-        new CredentialIssuer({ issuers: [jwt, ld] }),
+        new CredentialIssuer([jwt, ld]),
       ],
     })
     didKeyIdentifier = await agent.didManagerCreate()

--- a/packages/credential-w3c/src/__tests__/message-handler.test.ts
+++ b/packages/credential-w3c/src/__tests__/message-handler.test.ts
@@ -31,7 +31,7 @@ describe('@veramo/credential-w3c', () => {
                   id: `${didEthr}#owner`,
                   type: 'EcdsaSecp256k1RecoveryMethod2020',
                   controller: args?.didUrl,
-                  blockchainAccountId: `eip155:1:${didEthr.slice(-42)}`,
+                  blockchainAccountId: `eip155:5:${didEthr.slice(-42)}`,
                 },
               ],
               authentication: [`${didEthr}#owner`],

--- a/packages/credential-w3c/src/abstract-credential-provider.ts
+++ b/packages/credential-w3c/src/abstract-credential-provider.ts
@@ -1,116 +1,36 @@
-import { IAgentContext, ICanIssueCredentialTypeArgs, ICanVerifyDocumentTypeArgs, ICreateVerifiableCredentialArgs, ICreateVerifiablePresentationArgs, IIdentifier, IKey, IssuerAgentContext, IVerifyCredentialArgs, IVerifyPresentationArgs, IVerifyResult, VerifiableCredential, VerifiablePresentation, VerifierAgentContext } from "@veramo/core-types";
+import { ICanVerifyDocumentTypeArgs, ICredentialIssuer, ICredentialVerifier, IKey } from '@veramo/core-types'
+
+export type IssuerMethods = Pick<
+  ICredentialIssuer,
+  'createVerifiableCredential' | 'createVerifiablePresentation' | 'canIssueCredentialType'
+>
+export type VerifierMethods = Pick<ICredentialVerifier, 'verifyCredential' | 'verifyPresentation'>
 
 /**
- * The interface definition for a plugin that can generate Verifiable Credentials and Presentations
+ * The interface definition for a sub-plugin that can issue and verify Verifiable Data
+ * (e.g. Verifiable Credentials and Presentations)
  *
- * @see {@link @veramo/credential-w3c#CredentialPlugin} for an implementation.
+ * @see {@link @veramo/credential-jwt#CredentialPlugin} for an implementation.
  * @remarks Please see {@link https://www.w3.org/TR/vc-data-model | W3C Verifiable Credentials data model}
  *
  * @public
  */
-export abstract class AbstractCredentialProvider {
-    /**
-     * Creates a Verifiable Presentation.
-     * The payload, signer and format are chosen based on the `args` parameter.
-     *
-     * @param args - Arguments necessary to create the Presentation.
-     * @param context - This reserved param is automatically added and handled by the framework, *do not override*
-     *
-     * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiablePresentation} that was requested or
-     *   rejects with an error if there was a problem with the input or while getting the key to sign
-     *
-     * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#presentations | Verifiable Presentation data model
-     *   }
-     */
-    abstract createVerifiablePresentation(
-        args: ICreateVerifiablePresentationArgs,
-        context: IssuerAgentContext,
-    ): Promise<VerifiablePresentation>
+export interface ICredentialProvider extends IssuerMethods, VerifierMethods {
+  /**
+   * Lists the proof formats supported by this provider for a given key
+   * @param key - The key to check supported proof formats for
+   *
+   * @returns An array of supported proof format strings
+   */
+  getProofFormatsSupportedForKey(key: IKey): string[]
 
-    /**
-     * Creates a Verifiable Presentation.
-     * The payload, signer and format are chosen based on the `args` parameter.
-     *
-     * @param args - Arguments necessary to create the Presentation.
-     * @param context - This reserved param is automatically added and handled by the framework, *do not override*
-     *
-     * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiablePresentation} that was requested or
-     *   rejects with an error if there was a problem with the input or while getting the key to sign
-     *
-     * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#presentations | Verifiable Presentation data model
-    *   }
-    */
-    abstract canIssueCredentialType(args: ICanIssueCredentialTypeArgs): boolean
-
-
-    /**
-     * Matches a key against the type of proof supported by this issuer
-     * 
-     * @param key - The key to match against the proof type(s) supported by this issuer
-     * @param context - This reserved param is automatically added and handled by the framework, *do not override*
-     * 
-     * @returns - a promise that resolves to a boolean indicating if the key can be used to sign a credential with this issuer
-     */
-    abstract matchKeyForType(key: IKey): boolean
-
-    /**
-     * Gets the proof type supported by this issuer
-     * 
-     * @returns - a promise that resolves to a string of the proof format supported by this issuer
-     */
-    abstract getTypeProofFormat(): string
-
-    /**
-     * Creates a Verifiable Credential.
-     * The payload, signer and format are chosen based on the `args` parameter.
-     *
-     * @param args - Arguments necessary to create the Presentation.
-     * @param context - This reserved param is automatically added and handled by the framework, *do not override*
-     *
-     * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiableCredential} that was requested or
-     *   rejects with an error if there was a problem with the input or while getting the key to sign
-     *
-     * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#credentials | Verifiable Credential data model}
-     */
-    abstract createVerifiableCredential(
-        args: ICreateVerifiableCredentialArgs,
-        context: IssuerAgentContext,
-    ): Promise<VerifiableCredential>
-
-    /**
-     * Verifies a Verifiable Credential
-     *
-     * @param args - Arguments necessary to verify a VerifiableCredential
-     * @param context - This reserved param is automatically added and handled by the framework, *do not override*
-     *
-     * @returns - a promise that resolves to an object containing a `verified` boolean property and an optional `error`
-     *   for details
-     *
-     * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#credentials | Verifiable Credential data model}
-     */
-    abstract verifyCredential(args: IVerifyCredentialArgs, context: VerifierAgentContext): Promise<IVerifyResult>
-
-
-    /**
-     * 
-     * @param args - Arguments necessary to verify a document
-     * @param context  - This reserved param is automatically added and handled by the framework, *do not override*
-     * 
-     * @returns a promise that resolves to a boolean indicating if the document can be verified
-     */
-    abstract canVerifyDocumentType(args: ICanVerifyDocumentTypeArgs): boolean
-
-    /**
-     * Verifies a Verifiable Presentation JWT or LDS Format.
-     *
-     * @param args - Arguments necessary to verify a VerifiableCredential
-     * @param context - This reserved param is automatically added and handled by the framework, *do not override*
-     *
-     * @returns - a promise that resolves to an object containing a `verified` boolean property and an optional `error`
-     *   for details
-     *
-     * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#presentations | Verifiable Credential data model}
-     */
-    abstract verifyPresentation(args: IVerifyPresentationArgs, context: VerifierAgentContext): Promise<IVerifyResult>
-
+  /**
+   * Checks if this provider can verify a piece of data.
+   *
+   * @param args - Arguments necessary to verify a document
+   * @param context  - This reserved param is automatically added and handled by the framework, *do not override*
+   *
+   * @returns a promise that resolves to a boolean indicating if the document can be verified
+   */
+  canVerifyDocumentType(args: ICanVerifyDocumentTypeArgs): boolean
 }

--- a/packages/credential-w3c/src/abstract-credential-provider.ts
+++ b/packages/credential-w3c/src/abstract-credential-provider.ts
@@ -1,16 +1,50 @@
-import { ICanVerifyDocumentTypeArgs, ICredentialIssuer, ICredentialVerifier, IKey } from '@veramo/core-types'
+import {
+  ICredentialIssuer,
+  ICredentialVerifier,
+  IKey,
+  ProofFormat,
+  W3CVerifiableCredential,
+  W3CVerifiablePresentation,
+} from '@veramo/core-types'
 
+/**
+ * Subset of issuer methods implemented by Credential Providers
+ *
+ * @internal
+ */
 export type IssuerMethods = Pick<
   ICredentialIssuer,
-  'createVerifiableCredential' | 'createVerifiablePresentation' | 'canIssueCredentialType'
+  'createVerifiableCredential' | 'createVerifiablePresentation'
 >
+
+/**
+ * Subset of verifier methods implemented by Credential Providers
+ *
+ * @internal
+ */
 export type VerifierMethods = Pick<ICredentialVerifier, 'verifyCredential' | 'verifyPresentation'>
+
+/**
+ * Query a {@link ICredentialProvider} if a verification attempt can be made using the provided document
+ *
+ * @see {@link ICredentialProvider.canVerifyDocumentType}
+ * @public
+ */
+export type TentativeVerificationQuery = { document: W3CVerifiableCredential | W3CVerifiablePresentation }
+
+/**
+ * Query a {@link ICredentialProvider} for a particular proof format
+ *
+ * @see {@link ICredentialProvider.canIssueProofFormat}
+ * @public
+ */
+export type ProofFormatQuery = { proofFormat: ProofFormat }
 
 /**
  * The interface definition for a sub-plugin that can issue and verify Verifiable Data
  * (e.g. Verifiable Credentials and Presentations)
  *
- * @see {@link @veramo/credential-jwt#CredentialPlugin} for an implementation.
+ * @see {@link @veramo/credential-jwt#CredentialProviderJWT} for an implementation.
  * @remarks Please see {@link https://www.w3.org/TR/vc-data-model | W3C Verifiable Credentials data model}
  *
  * @public
@@ -25,12 +59,19 @@ export interface ICredentialProvider extends IssuerMethods, VerifierMethods {
   getProofFormatsSupportedForKey(key: IKey): string[]
 
   /**
-   * Checks if this provider can verify a piece of data.
+   * Checks if this provider can attempt to verify a document.
    *
-   * @param args - Arguments necessary to verify a document
-   * @param context  - This reserved param is automatically added and handled by the framework, *do not override*
+   * @param query - contains the document to check
    *
-   * @returns a promise that resolves to a boolean indicating if the document can be verified
+   * @returns a boolean indicating if a verification attempt can be made
    */
-  canVerifyDocumentType(args: ICanVerifyDocumentTypeArgs): boolean
+  canVerifyDocumentType(query: TentativeVerificationQuery): boolean
+
+  /**
+   * Checks if this provider can issue a credential or presentation in a particular format.
+   * @param query - The proof format to check
+   *
+   * @returns a boolean indicating if the credential or presentation can be issued in that format
+   */
+  canIssueProofFormat(query: ProofFormatQuery): boolean
 }

--- a/packages/credential-w3c/src/abstract-credential-provider.ts
+++ b/packages/credential-w3c/src/abstract-credential-provider.ts
@@ -56,7 +56,7 @@ export interface ICredentialProvider extends IssuerMethods, VerifierMethods {
    *
    * @returns An array of supported proof format strings
    */
-  getProofFormatsSupportedForKey(key: IKey): string[]
+  getProofFormatsSupportedForKey(key: IKey): ProofFormat[]
 
   /**
    * Checks if this provider can attempt to verify a document.

--- a/packages/credential-w3c/src/action-handler.ts
+++ b/packages/credential-w3c/src/action-handler.ts
@@ -11,12 +11,13 @@ import {
   IVerifyCredentialArgs,
   IVerifyPresentationArgs,
   IVerifyResult,
+  ProofFormat,
   VerifiableCredential,
   VerifiablePresentation,
   VerifierAgentContext,
 } from '@veramo/core-types'
 
-import { AbstractCredentialProvider } from './abstract-credential-provider.js'
+import { ICredentialProvider } from './abstract-credential-provider.js'
 
 import { schema } from '@veramo/core-types'
 
@@ -50,10 +51,10 @@ export class CredentialPlugin implements IAgentPlugin {
       },
     },
   }
-  private issuers: AbstractCredentialProvider[]
+  private issuers: ICredentialProvider[]
 
-  constructor(options: { issuers: AbstractCredentialProvider[] }) {
-    this.issuers = options.issuers
+  constructor(issuers: ICredentialProvider[]) {
+    this.issuers = issuers
     this.methods = {
       listUsableProofFormats: this.listUsableProofFormats.bind(this),
       createVerifiableCredential: this.createVerifiableCredential.bind(this),
@@ -63,14 +64,12 @@ export class CredentialPlugin implements IAgentPlugin {
     }
   }
 
-  async listUsableProofFormats(did: IIdentifier, context: IssuerAgentContext): Promise<string[]> {
+  async listUsableProofFormats(did: IIdentifier, context: IssuerAgentContext): Promise<ProofFormat[]> {
     const signingOptions: string[] = []
     const keys = did.keys
     for (const key of keys) {
       for (const issuer of this.issuers) {
-        if (issuer.matchKeyForType(key)) {
-          signingOptions.push(issuer.getTypeProofFormat())
-        }
+        signingOptions.push(...issuer.getProofFormatsSupportedForKey(key))
       }
     }
     return signingOptions
@@ -112,14 +111,14 @@ export class CredentialPlugin implements IAgentPlugin {
     try {
       let verifiableCredential: VerifiableCredential | undefined
 
-      async function getCredential(issuers: AbstractCredentialProvider[]) {
+      async function tryToIssueCredential(issuers: ICredentialProvider[]) {
         for (const issuer of issuers) {
-          if (issuer.canIssueCredentialType({ proofFormat })) {
+          if (await issuer.canIssueCredentialType({ proofFormat }, context)) {
             return await issuer.createVerifiableCredential(args, context)
           }
         }
       }
-      verifiableCredential = await getCredential(this.issuers)
+      verifiableCredential = await tryToIssueCredential(this.issuers)
 
       if (!verifiableCredential) {
         throw new Error('invalid_setup: No issuer found for the requested proof format')
@@ -142,7 +141,7 @@ export class CredentialPlugin implements IAgentPlugin {
     let verifiedCredential: VerifiableCredential
     let verificationResult: IVerifyResult | undefined = { verified: false }
 
-    async function getVerificationResult(issuers: AbstractCredentialProvider[]): Promise<IVerifyResult | undefined> {
+    async function getVerificationResult(issuers: ICredentialProvider[]): Promise<IVerifyResult | undefined> {
       for (const issuer of issuers) {
         if (issuer.canVerifyDocumentType({ document: credential })) {
           return issuer.verifyCredential(args, context)
@@ -212,15 +211,15 @@ export class CredentialPlugin implements IAgentPlugin {
 
     let verifiablePresentation: VerifiablePresentation | undefined
 
-    async function getPresentation(issuers: AbstractCredentialProvider[]) {
+    async function tryToCreatePresentation(issuers: ICredentialProvider[]) {
       for (const issuer of issuers) {
-        if (issuer.canIssueCredentialType({ proofFormat })) {
+        if (await issuer.canIssueCredentialType({ proofFormat }, context)) {
           return await issuer.createVerifiablePresentation(args, context)
         }
       }
     }
 
-    verifiablePresentation = await getPresentation(this.issuers)
+    verifiablePresentation = await tryToCreatePresentation(this.issuers)
 
     if (!verifiablePresentation) {
       throw new Error('invalid_setup: No issuer found for the requested proof format')
@@ -239,7 +238,7 @@ export class CredentialPlugin implements IAgentPlugin {
   ): Promise<IVerifyResult> {
     let { presentation, domain, challenge, fetchRemoteContexts, policies, ...otherOptions } = args
     let result: IVerifyResult | undefined = { verified: false }
-    async function getVerificationResult(issuers: AbstractCredentialProvider[]): Promise<IVerifyResult | undefined> {
+    async function getVerificationResult(issuers: ICredentialProvider[]): Promise<IVerifyResult | undefined> {
       for (const issuer of issuers) {
         if (issuer.canVerifyDocumentType({ document: presentation })) {
           return issuer.verifyPresentation(args, context)

--- a/packages/credential-w3c/src/action-handler.ts
+++ b/packages/credential-w3c/src/action-handler.ts
@@ -6,12 +6,12 @@ import {
   ICredentialPlugin,
   ICredentialStatusVerifier,
   IIdentifier,
-  IKey,
   IssuerAgentContext,
   IVerifyCredentialArgs,
   IVerifyPresentationArgs,
   IVerifyResult,
   ProofFormat,
+  schema,
   VerifiableCredential,
   VerifiablePresentation,
   VerifierAgentContext,
@@ -19,15 +19,7 @@ import {
 
 import { ICredentialProvider } from './abstract-credential-provider.js'
 
-import { schema } from '@veramo/core-types'
-
-import {
-  extractIssuer,
-  removeDIDParameters,
-  isDefined,
-  MANDATORY_CREDENTIAL_CONTEXT,
-  processEntryToArray,
-} from '@veramo/utils'
+import { extractIssuer, isDefined, MANDATORY_CREDENTIAL_CONTEXT, processEntryToArray } from '@veramo/utils'
 import Debug from 'debug'
 
 const debug = Debug('veramo:w3c:action-handler')
@@ -251,22 +243,6 @@ export class CredentialPlugin implements IAgentPlugin {
     }
     return result
   }
-}
-
-function pickSigningKey(identifier: IIdentifier, keyRef?: string): IKey {
-  let key: IKey | undefined
-
-  if (!keyRef) {
-    key = identifier.keys.find(
-      (k) => k.type === 'Secp256k1' || k.type === 'Ed25519' || k.type === 'Secp256r1',
-    )
-    if (!key) throw Error('key_not_found: No signing key for ' + identifier.did)
-  } else {
-    key = identifier.keys.find((k) => k.kid === keyRef)
-    if (!key) throw Error('key_not_found: No signing key for ' + identifier.did + ' with kid ' + keyRef)
-  }
-
-  return key as IKey
 }
 
 async function isRevoked(

--- a/packages/credential-w3c/src/action-handler.ts
+++ b/packages/credential-w3c/src/action-handler.ts
@@ -56,6 +56,7 @@ export class CredentialPlugin implements IAgentPlugin {
     }
   }
 
+  /** {@inheritdoc @veramo/core-types#ICredentialIssuer.listUsableProofFormats} */
   async listUsableProofFormats(did: IIdentifier, context: IssuerAgentContext): Promise<ProofFormat[]> {
     const signingOptions: string[] = []
     const keys = did.keys
@@ -105,7 +106,7 @@ export class CredentialPlugin implements IAgentPlugin {
 
       async function tryToIssueCredential(issuers: ICredentialProvider[]) {
         for (const issuer of issuers) {
-          if (await issuer.canIssueCredentialType({ proofFormat }, context)) {
+          if (issuer.canIssueProofFormat({ proofFormat })) {
             return await issuer.createVerifiableCredential(args, context)
           }
         }
@@ -129,9 +130,7 @@ export class CredentialPlugin implements IAgentPlugin {
 
   /** {@inheritdoc @veramo/core-types#ICredentialVerifier.verifyCredential} */
   async verifyCredential(args: IVerifyCredentialArgs, context: VerifierAgentContext): Promise<IVerifyResult> {
-    let { credential, policies, ...otherOptions } = args
-    let verifiedCredential: VerifiableCredential
-    let verificationResult: IVerifyResult | undefined = { verified: false }
+    let { credential, policies } = args
 
     async function getVerificationResult(issuers: ICredentialProvider[]): Promise<IVerifyResult | undefined> {
       for (const issuer of issuers) {
@@ -140,11 +139,11 @@ export class CredentialPlugin implements IAgentPlugin {
         }
       }
     }
-    verificationResult = await getVerificationResult(this.issuers)
+    let verificationResult = await getVerificationResult(this.issuers)
     if (!verificationResult) {
       throw new Error('invalid_setup: No verifier found for the provided credential')
     }
-    verifiedCredential = <VerifiableCredential>credential
+    const verifiedCredential = <VerifiableCredential>credential
 
     if (policies?.credentialStatus !== false && (await isRevoked(verifiedCredential, context as any))) {
       verificationResult = {
@@ -164,17 +163,7 @@ export class CredentialPlugin implements IAgentPlugin {
     args: ICreateVerifiablePresentationArgs,
     context: IssuerAgentContext,
   ): Promise<VerifiablePresentation> {
-    let {
-      presentation,
-      proofFormat,
-      domain,
-      challenge,
-      removeOriginalFields,
-      keyRef,
-      save,
-      now,
-      ...otherOptions
-    } = args
+    let { presentation, proofFormat, save } = args
     const presentationContext: string[] = processEntryToArray(
       args?.presentation?.['@context'],
       MANDATORY_CREDENTIAL_CONTEXT,
@@ -201,17 +190,15 @@ export class CredentialPlugin implements IAgentPlugin {
       })
     }
 
-    let verifiablePresentation: VerifiablePresentation | undefined
-
     async function tryToCreatePresentation(issuers: ICredentialProvider[]) {
       for (const issuer of issuers) {
-        if (await issuer.canIssueCredentialType({ proofFormat }, context)) {
+        if (issuer.canIssueProofFormat({ proofFormat })) {
           return await issuer.createVerifiablePresentation(args, context)
         }
       }
     }
 
-    verifiablePresentation = await tryToCreatePresentation(this.issuers)
+    let verifiablePresentation = await tryToCreatePresentation(this.issuers)
 
     if (!verifiablePresentation) {
       throw new Error('invalid_setup: No issuer found for the requested proof format')
@@ -228,16 +215,14 @@ export class CredentialPlugin implements IAgentPlugin {
     args: IVerifyPresentationArgs,
     context: VerifierAgentContext,
   ): Promise<IVerifyResult> {
-    let { presentation, domain, challenge, fetchRemoteContexts, policies, ...otherOptions } = args
-    let result: IVerifyResult | undefined = { verified: false }
-    async function getVerificationResult(issuers: ICredentialProvider[]): Promise<IVerifyResult | undefined> {
+    async function tryVerification(issuers: ICredentialProvider[]): Promise<IVerifyResult | undefined> {
       for (const issuer of issuers) {
-        if (issuer.canVerifyDocumentType({ document: presentation })) {
+        if (issuer.canVerifyDocumentType({ document: args.presentation })) {
           return issuer.verifyPresentation(args, context)
         }
       }
     }
-    result = await getVerificationResult(this.issuers)
+    let result = await tryVerification(this.issuers)
     if (!result) {
       throw new Error('invalid_setup: No verifier found for the provided presentation')
     }

--- a/packages/credential-w3c/src/index.ts
+++ b/packages/credential-w3c/src/index.ts
@@ -21,4 +21,4 @@ export { CredentialIssuer, CredentialPlugin }
 // For backward compatibility, re-export the plugin types that were moved to core in v4
 export type { ICredentialIssuer, ICredentialVerifier } from '@veramo/core-types'
 
-export { AbstractCredentialProvider } from './abstract-credential-provider.js'
+export type { ICredentialProvider } from './abstract-credential-provider.js'

--- a/packages/credential-w3c/src/index.ts
+++ b/packages/credential-w3c/src/index.ts
@@ -21,4 +21,8 @@ export { CredentialIssuer, CredentialPlugin }
 // For backward compatibility, re-export the plugin types that were moved to core in v4
 export type { ICredentialIssuer, ICredentialVerifier } from '@veramo/core-types'
 
-export type { ICredentialProvider } from './abstract-credential-provider.js'
+export type {
+  ICredentialProvider,
+  ProofFormatQuery,
+  TentativeVerificationQuery,
+} from './abstract-credential-provider.js'

--- a/packages/data-store/src/entities/credential.ts
+++ b/packages/data-store/src/entities/credential.ts
@@ -54,7 +54,7 @@ export class Credential extends BaseEntity {
   // @ts-ignore
   issuer: Relation<Identifier>
 
-  // Subject can be null https://w3c.github.io/vc-data-model/#credential-uniquely-identifies-a-subject
+  // Subject can be null https://www.w3.org/TR/vc-data-model-1.1/#credential-uniquely-identifies-a-subject
   @ManyToOne((type) => Identifier, (identifier) => identifier?.receivedCredentials, {
     cascade: ['insert'],
     eager: true,

--- a/packages/did-comm/src/plugin.schema.ts
+++ b/packages/did-comm/src/plugin.schema.ts
@@ -512,7 +512,7 @@ export const schema = {
             "id",
             "type"
           ],
-          "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information is determined by the specific `credentialStatus` type definition, and varies depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
+          "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information are determined by the specific `credentialStatus` type  definition and vary depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
         },
         "VerifiablePresentation": {
           "type": "object",
@@ -577,7 +577,7 @@ export const schema = {
               "$ref": "#/components/schemas/CompactJWT"
             }
           ],
-          "description": "Represents a signed Verifiable Credential (includes proof), in either JSON or compact JWT format. See  {@link https://www.w3.org/TR/vc-data-model/#credentials | VC data model }  See  {@link https://www.w3.org/TR/vc-data-model/#proof-formats | proof formats }"
+          "description": "Represents a signed Verifiable Credential (includes proof), in either JSON or compact JWT format. See  {@link https://www.w3.org/TR/vc-data-model/#credentials | VC data model }  See  {@link https://www.w3.org/TR/vc-data-model-1.1/#proof-formats | proof formats }"
         },
         "CompactJWT": {
           "type": "string",

--- a/packages/did-provider-jwk/src/types/jwk-provider-types.ts
+++ b/packages/did-provider-jwk/src/types/jwk-provider-types.ts
@@ -1,6 +1,9 @@
-import { RequireOnly, KeyMetadata } from '@veramo/core-types'
-import { JwkDidSupportedKeyTypes, KeyUse, CreateIdentifierBaseOptions } from '@veramo/utils'
+import { CreateIdentifierBaseOptions, JwkDidSupportedKeyTypes, KeyUse } from '@veramo/utils'
 
+/**
+ * Options for creating a JWK DID identifier
+ * @internal
+ */
 export type JwkCreateIdentifierOptions = CreateIdentifierBaseOptions<JwkDidSupportedKeyTypes> & {
   /**
    * @deprecated use key.type instead

--- a/packages/kv-store/src/store-adapters/typeorm/index.ts
+++ b/packages/kv-store/src/store-adapters/typeorm/index.ts
@@ -9,6 +9,10 @@ import JSONB from 'json-buffer'
 
 export { KeyValueTypeORMOptions } from './types.js'
 
+/**
+ * Entities used by the TypeORM key value store adapter
+ * @beta
+ */
 export const Entities = [KeyValueStoreEntity]
 
 /**

--- a/packages/selective-disclosure/src/plugin.schema.ts
+++ b/packages/selective-disclosure/src/plugin.schema.ts
@@ -116,7 +116,7 @@ export const schema = {
               "$ref": "#/components/schemas/CompactJWT"
             }
           ],
-          "description": "Represents a signed Verifiable Credential (includes proof), in either JSON or compact JWT format. See  {@link https://www.w3.org/TR/vc-data-model/#credentials | VC data model }  See  {@link https://www.w3.org/TR/vc-data-model/#proof-formats | proof formats }"
+          "description": "Represents a signed Verifiable Credential (includes proof), in either JSON or compact JWT format. See  {@link https://www.w3.org/TR/vc-data-model/#credentials | VC data model }  See  {@link https://www.w3.org/TR/vc-data-model-1.1/#proof-formats | proof formats }"
         },
         "VerifiableCredential": {
           "type": "object",
@@ -234,7 +234,7 @@ export const schema = {
             "id",
             "type"
           ],
-          "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information is determined by the specific `credentialStatus` type definition, and varies depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
+          "description": "Used for the discovery of information about the current status of a verifiable credential, such as whether it is suspended or revoked. The precise contents of the credential status information are determined by the specific `credentialStatus` type  definition and vary depending on factors such as whether it is simple to implement or if it is privacy-enhancing.\n\nSee  {@link https://www.w3.org/TR/vc-data-model/#status | Credential Status }"
         },
         "CompactJWT": {
           "type": "string",

--- a/packages/test-react-app/src/veramo/setup.ts
+++ b/packages/test-react-app/src/veramo/setup.ts
@@ -158,7 +158,7 @@ export function getAgent(options?: IAgentOptions): TAgent<InstalledPlugins> {
         ],
       }),
       new DIDComm(),
-      new CredentialPlugin({ issuers: [jwt, ld] }),
+      new CredentialPlugin([jwt, ld]),
       new SelectiveDisclosure(),
       ...(options?.plugins || []),
     ],

--- a/packages/utils/src/__tests__/did-utils.test.ts
+++ b/packages/utils/src/__tests__/did-utils.test.ts
@@ -1,4 +1,9 @@
-import { extractPublicKeyHex, getChainId, getEthereumAddress } from '../did-utils.js'
+import {
+  compressSecp256k1PublicKeyHex,
+  extractPublicKeyHex,
+  getChainId,
+  getEthereumAddress,
+} from '../did-utils.js'
 import { bytesToMultibase, hexToBytes } from '../encodings.js'
 
 describe('@veramo/utils did utils', () => {
@@ -40,26 +45,24 @@ describe('@veramo/utils did utils', () => {
   it('should return correct chainId for did:pkh', () => {
     expect(
       getChainId({
-        "id": "did:pkh:eip155:59144:0x19711CD19e609FEBdBF607960220898268B7E24b#blockchainAccountId",
-        "type": "EcdsaSecp256k1RecoveryMethod2020",
-        "controller": "did:pkh:eip155:59144:0x19711CD19e609FEBdBF607960220898268B7E24b",
-        "blockchainAccountId": "eip155:59144:0x19711CD19e609FEBdBF607960220898268B7E24b"
+        id: 'did:pkh:eip155:59144:0x19711CD19e609FEBdBF607960220898268B7E24b#blockchainAccountId',
+        type: 'EcdsaSecp256k1RecoveryMethod2020',
+        controller: 'did:pkh:eip155:59144:0x19711CD19e609FEBdBF607960220898268B7E24b',
+        blockchainAccountId: 'eip155:59144:0x19711CD19e609FEBdBF607960220898268B7E24b',
       }),
     ).toEqual(59144)
   })
 
-
   it('should throw on invalid chainId', () => {
-    expect( () => {
+    expect(() => {
       getChainId({
-        "id": "did:pkh:eip155:59144:0x19711CD19e609FEBdBF607960220898268B7E24b#blockchainAccountId",
-        "type": "EcdsaSecp256k1RecoveryMethod2020",
-        "controller": "did:pkh:eip155:59144:0x19711CD19e609FEBdBF607960220898268B7E24b",
-        "blockchainAccountId": "eip155:linea:0x19711CD19e609FEBdBF607960220898268B7E24b"
+        id: 'did:pkh:eip155:59144:0x19711CD19e609FEBdBF607960220898268B7E24b#blockchainAccountId',
+        type: 'EcdsaSecp256k1RecoveryMethod2020',
+        controller: 'did:pkh:eip155:59144:0x19711CD19e609FEBdBF607960220898268B7E24b',
+        blockchainAccountId: 'eip155:linea:0x19711CD19e609FEBdBF607960220898268B7E24b',
       })
-    }).toThrow("chainId is not a number")
+    }).toThrow('chainId is not a number')
   })
-
 
   it('should return blockchainAccountId for did:ethr', () => {
     const verificationMethod = {
@@ -135,5 +138,13 @@ describe('@veramo/utils did utils', () => {
     })
 
     expect(computed).toEqual({ publicKeyHex, keyType: 'Ed25519' })
+  })
+
+  it('compresses a secp256k1 public key', async () => {
+    const uncompressedPubKeyHex =
+      '04a5c9734922890f0e76cce0bb2645925a9712fe89eb00eb2d9c480208a5de48cbaded6443a8668e0eef5205d08e7614374d659a1aa1beb0ef9ffec810988f2da3'
+    const compressedPubKeyHex = '03a5c9734922890f0e76cce0bb2645925a9712fe89eb00eb2d9c480208a5de48cb'
+    expect(compressSecp256k1PublicKeyHex(uncompressedPubKeyHex)).toEqual(compressedPubKeyHex)
+    expect(compressSecp256k1PublicKeyHex(compressedPubKeyHex)).toEqual(compressedPubKeyHex) // no change
   })
 })

--- a/packages/utils/src/did-utils.ts
+++ b/packages/utils/src/did-utils.ts
@@ -1,5 +1,13 @@
 import { computeAddress, SigningKey } from 'ethers'
-import { DIDDocumentSection, IAgentContext, IIdentifier, IKey, IKeyManager, IResolver, KeyMetadata, IKeyManagerCreateArgs, MinimalImportableKey, RequireOnly, TKeyType } from '@veramo/core-types'
+import {
+  DIDDocumentSection,
+  IAgentContext,
+  IIdentifier,
+  IKey,
+  IKeyManager,
+  IResolver,
+  TKeyType,
+} from '@veramo/core-types'
 import { DIDDocument, DIDResolutionOptions, VerificationMethod } from 'did-resolver'
 import { extractPublicKeyBytes } from 'did-jwt'
 import {
@@ -95,6 +103,20 @@ export function compressIdentifierSecp256k1Keys(identifier: IIdentifier): IKey[]
       return key
     })
     .filter(isDefined)
+}
+
+/**
+ * Compresses a Secp256k1 public key in hex format.
+ *
+ * @returns the compressed public key hex string without 0x prefix, or an empty string if no input was provided.
+ * @param publicKeyHex - the (un)compressed public key hex string
+ */
+export function compressSecp256k1PublicKeyHex(publicKeyHex?: string): string {
+  if (typeof publicKeyHex !== 'string') {
+    return ''
+  }
+  const publicBytes = hexToBytes(publicKeyHex)
+  return SigningKey.computePublicKey(publicBytes, true).substring(2)
 }
 
 /**
@@ -202,7 +224,7 @@ export async function mapIdentifierKeysToDoc(
   resolutionOptions?: DIDResolutionOptions,
 ): Promise<_ExtendedIKey[]> {
   const didDocument = await resolveDidOrThrow(identifier.did, context, resolutionOptions)
-  // dereference all key agreement keys from DID document and normalize
+  // dereference all key agreement keys from the DID document and normalize
   const documentKeys: _NormalizedVerificationMethod[] = await dereferenceDidKeys(
     didDocument,
     section,
@@ -215,8 +237,8 @@ export async function mapIdentifierKeysToDoc(
   } else {
     localKeys = compressIdentifierSecp256k1Keys(identifier)
   }
-  // finally map the didDocument keys to the identifier keys by comparing `publicKeyHex`
-  const extendedKeys: _ExtendedIKey[] = documentKeys
+  // finally, map the didDocument keys to the identifier keys by comparing `publicKeyHex`
+  return documentKeys
     .map((verificationMethod) => {
       const localKey = localKeys.find(
         (localKey: IKey) =>
@@ -231,8 +253,6 @@ export async function mapIdentifierKeysToDoc(
       }
     })
     .filter(isDefined)
-
-  return extendedKeys
 }
 
 /**
@@ -330,7 +350,8 @@ export async function dereferenceDidKeys(
 }
 
 /**
- * Converts the publicKey of a VerificationMethod to hex encoding (publicKeyHex)
+ * Converts the publicKey of a VerificationMethod to hex encoding (publicKeyHex), with no 0x prefix.
+ * Secp256k1 public keys are compressed.
  *
  * @param pk - the VerificationMethod to be converted
  * @param convert - when this flag is set to true, Ed25519 keys are converted to their X25519 pairs
@@ -352,7 +373,9 @@ export function extractPublicKeyHex(
       keyType = 'X25519'
     }
   }
-  return { publicKeyHex: bytesToHex(keyBytes), keyType }
+  const publicKeyHex =
+    keyType === 'Secp256k1' ? compressSecp256k1PublicKeyHex(bytesToHex(keyBytes)) : bytesToHex(keyBytes)
+  return { publicKeyHex, keyType }
 }
 
 export function pickSigningKey(identifier: IIdentifier, keyRef?: string): IKey {
@@ -373,7 +396,7 @@ export function pickSigningKey(identifier: IIdentifier, keyRef?: string): IKey {
 
 export async function importOrCreateKey<K extends TKeyType = TKeyType>(
   args: {
-    kms: string,
+    kms: string
     options: ImportOrCreateKeyOptions<K>
   },
   context: IAgentContext<IKeyManager>,

--- a/packages/utils/src/did-utils.ts
+++ b/packages/utils/src/did-utils.ts
@@ -110,6 +110,7 @@ export function compressIdentifierSecp256k1Keys(identifier: IIdentifier): IKey[]
  *
  * @returns the compressed public key hex string without 0x prefix, or an empty string if no input was provided.
  * @param publicKeyHex - the (un)compressed public key hex string
+ * @internal
  */
 export function compressSecp256k1PublicKeyHex(publicKeyHex?: string): string {
   if (typeof publicKeyHex !== 'string') {
@@ -378,6 +379,14 @@ export function extractPublicKeyHex(
   return { publicKeyHex, keyType }
 }
 
+/**
+ * Picks a signing key from a managed identifier.
+ * If a keyRef is provided, it tries to find the key with that kid. Otherwise, it picks the first available
+ * signing key based on known key types and algorithms.
+ * @param identifier - the identifier to pick the signing key from
+ * @param keyRef - optional key reference (kid) to select a specific key
+ * @internal
+ */
 export function pickSigningKey(identifier: IIdentifier, keyRef?: string): IKey {
   let key: IKey | undefined
 
@@ -394,6 +403,13 @@ export function pickSigningKey(identifier: IIdentifier, keyRef?: string): IKey {
   return key as IKey
 }
 
+/**
+ * Imports a key if privateKeyHex is provided, otherwise creates a new key.
+ *
+ * @param args - The arguments for importing or creating the key.
+ * @param context - The agent context containing the key manager.
+ * @internal
+ */
 export async function importOrCreateKey<K extends TKeyType = TKeyType>(
   args: {
     kms: string

--- a/packages/utils/src/jwk-did-utils.ts
+++ b/packages/utils/src/jwk-did-utils.ts
@@ -5,6 +5,14 @@ import { p256 } from '@noble/curves/p256'
 import { bytesToBase64url, hexToBytes } from 'did-jwt'
 import { extractPublicKeyHex } from './did-utils.js'
 
+/**
+ * Determine the key use based on the type of key and an optional passed key use param.
+ * @param keyType - The type of key (e.g., 'Ed25519', 'X25519', 'Secp256k1', 'Secp256r1').
+ * @param passedKeyUse - Optional key use parameter ('sig' for signature, 'enc' for encryption).
+ *
+ * @returns The determined key use ('sig' or 'enc').
+ * @internal
+ */
 export function getKeyUse(keyType: JwkDidSupportedKeyTypes, passedKeyUse?: KeyUse): KeyUse {
   if (passedKeyUse) {
     if (passedKeyUse !== 'sig' && passedKeyUse !== 'enc') {
@@ -30,6 +38,12 @@ export function getKeyUse(keyType: JwkDidSupportedKeyTypes, passedKeyUse?: KeyUs
   }
 }
 
+/**
+ * Check if the provided data is a valid JSON Web Key (JWK).
+ * @param data - The data to be checked.
+ *
+ * @internal
+ */
 export function isJWK(data: unknown): data is JsonWebKey {
   if (
     typeof data === 'object' &&
@@ -47,6 +61,16 @@ export function isJWK(data: unknown): data is JsonWebKey {
   return false
 }
 
+/**
+ * Create a JSON Web Key (JWK) from the given public key material and key type.
+ *
+ * @param keyType - The type of key (e.g., 'Ed25519', 'X25519', 'Secp256k1', 'Secp256r1').
+ * @param pubKey - The public key material as a hex string or Uint8Array.
+ * @param passedKeyUse - Optional key use parameter ('sig' for signature, 'enc' for encryption).
+ * @returns The generated JWK or undefined if the key type is not supported.
+ *
+ * @internal
+ */
 export function createJWK(
   keyType: JwkDidSupportedKeyTypes,
   pubKey: string | Uint8Array,
@@ -104,11 +128,21 @@ export function createJWK(
   }
 }
 
+/**
+ * Generate a JSON Web Key (JWK) from a given verification method.
+ *
+ * @param keyType - The type of key (e.g., 'Ed25519', 'X25519', 'Secp256k1', 'Secp256r1').
+ * @param key - The verification method containing the public key information.
+ * @param keyUse - Optional key use parameter ('sig' for signature, 'enc' for encryption).
+ * @returns The generated JWK.
+ *
+ * @internal
+ */
 export function generateJwkFromVerificationMethod(
   keyType: JwkDidSupportedKeyTypes,
   key: VerificationMethod,
   keyUse?: KeyUse,
 ) {
-  const { publicKeyHex, keyType: extractedType } = extractPublicKeyHex(key)
+  const { publicKeyHex } = extractPublicKeyHex(key)
   return createJWK(keyType, publicKeyHex, keyUse)
 }

--- a/packages/utils/src/types/utility-types.ts
+++ b/packages/utils/src/types/utility-types.ts
@@ -1,4 +1,4 @@
-import { IKey, KeyMetadata, TKeyType, IKeyManagerCreateArgs, MinimalImportableKey, RequireOnly } from '@veramo/core-types'
+import { IKey, IKeyManagerCreateArgs, KeyMetadata, MinimalImportableKey, TKeyType, } from '@veramo/core-types'
 
 import { VerificationMethod } from 'did-resolver'
 
@@ -47,23 +47,44 @@ export type OrPromise<T> = T | Promise<T>
  */
 export type RecordLike<T> = Map<string, T> | Record<string, T>
 
-export enum SupportedKeyTypes {
-  Secp256r1 = 'Secp256r1',
-  Secp256k1 = 'Secp256k1',
-  Ed25519 = 'Ed25519',
-  X25519 = 'X25519',
-}
+/**
+ * Supported key types for JWK DID method
+ * @internal
+ */
+export const SupportedKeyTypes = {
+  Secp256r1: 'Secp256r1',
+  Secp256k1: 'Secp256k1',
+  Ed25519: 'Ed25519',
+  X25519: 'X25519',
+} as const
 
+/**
+ * Key usage types as per JWK spec
+ * @see https://datatracker.ietf.org/doc/html/rfc7517#section-4.2
+ * @internal
+ */
 export type KeyUse = 'sig' | 'enc'
 
+/**
+ * Supported key types for JWK DID method
+ * @internal
+ */
 export type JwkDidSupportedKeyTypes = keyof typeof SupportedKeyTypes
 
+/**
+ * Options for importing or creating a key
+ * @internal
+ */
 export type ImportOrCreateKeyOptions<TKey extends TKeyType = TKeyType> = Omit<
   Partial<IKeyManagerCreateArgs & MinimalImportableKey>,
   'kms'
 > & { type: TKey }
 
+/**
+ * Basic options for creating an identifier
+ * @internal
+ */
 export type CreateIdentifierBaseOptions<T extends TKeyType = TKeyType> = {
-  keyRef?: string;
-  key?: ImportOrCreateKeyOptions<T>;
+  keyRef?: string
+  key?: ImportOrCreateKeyOptions<T>
 }


### PR DESCRIPTION
## What issue is this PR fixing

closes #1487

## What is being changed

BREAKING CHANGE: This changeset, along with the previous changes in #1395, modify the CredentialPlugin constructor to support extensibility without modifications to the Veramo repository. This plugin now acts as an orchestrator for other `ICredentialProvider` implementations that provide the actual support for various verifiable data formats. `ICredentialProvider` implementations can also be implemented externally and used with this plugin. The previous credential format plugins from this repository have already been converted to ICredentialProvider implementations.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [x] I added unit tests.
* [x] I added integration tests.

## Details
This change-set creates a breaking change to the `CredentialPlugin setup`.
The API for issuance and verification remains the same.

```ts
// Veramo agent setup up to Veramo <= v6
export const agent = createAgent({
  plugins: [
    //
    // ... other plugins
    //
    new CredentialPlugin(),
    new CredentialIssuerEIP712(),
    new CredentialIssuerLD({
      contextMaps: [LdDefaultContexts, credential_contexts as any],
      suites: [
        new VeramoEcdsaSecp256k1RecoverySignature2020(),
        new VeramoEd25519Signature2018(),
        new VeramoJsonWebSignature2020(),
        new VeramoEd25519Signature2020(),
      ],
    }),
  ],
})
```

```ts
// Veramo agent setup up going forward
export const agent = createAgent({
  plugins: [
    //
    // ... other plugins
    //
    new CredentialPlugin([
      new CredentialProviderJWT(),
      new CredentialProviderEIP712(),
      new CredentialProviderLD({
        contextMaps: [LdDefaultContexts, credential_contexts as any],
        suites: [
          new VeramoEcdsaSecp256k1RecoverySignature2020(),
          new VeramoEd25519Signature2018(),
          new VeramoJsonWebSignature2020(),
          new VeramoEd25519Signature2020(),
        ],
      }),
    ]),
  ],
})
```