### PR TITLE
fix(cli): update @veramo/cli setup and credential example for ICredentialProvider refactor

### DIFF
--- a/packages/cli/default/default.yml
+++ b/packages/cli/default/default.yml
@@ -292,9 +292,8 @@ CredentialProviderJWT:
 credentialPlugin:
   $require: "@veramo/credential-w3c#CredentialPlugin"
   $args:
-    - issuers:
-        - $ref: /CredentialProviderLD
-        - $ref: /CredentialProviderJWT
+    - - $ref: /CredentialProviderLD
+      - $ref: /CredentialProviderJWT
 
 # Agent
 agent:

--- a/packages/cli/src/credential.ts
+++ b/packages/cli/src/credential.ts
@@ -38,7 +38,8 @@ credential
           value: item.did,
         })),
         message: 'Issuer DID',
-      },])
+      },
+    ])
     const issuer = await agent.didManagerGet({ did: issuersQuery.iss })
     const usableProofFormats = await agent.listUsableProofFormats(issuer)
     const answers = await inquirer.prompt([
@@ -128,7 +129,7 @@ credential
     } else if (options.filename) {
       raw = await fs.promises.readFile(options.filename, 'utf-8')
     } else {
-      console.log('Please provide the credential as a JWT or JSON string. Press Ctrl+D to finish.');
+      console.log('Please provide the credential as a JWT or JSON string. Press Ctrl+D to finish.')
       raw = await readStdin()
     }
     let parsedCredential: any

--- a/packages/cli/src/credential.ts
+++ b/packages/cli/src/credential.ts
@@ -29,13 +29,7 @@ credential
       console.error('No dids')
       process.exit()
     }
-    const answers = await inquirer.prompt([
-      {
-        type: 'list',
-        name: 'proofFormat',
-        choices: ['jwt', 'lds', 'EthereumEip712Signature2021'],
-        message: 'Credential proofFormat',
-      },
+    const issuersQuery = await inquirer.prompt([
       {
         type: 'list',
         name: 'iss',
@@ -44,6 +38,15 @@ credential
           value: item.did,
         })),
         message: 'Issuer DID',
+      },])
+    const issuer = await agent.didManagerGet({ did: issuersQuery.iss })
+    const usableProofFormats = await agent.listUsableProofFormats(issuer)
+    const answers = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'proofFormat',
+        choices: usableProofFormats,
+        message: 'Credential proofFormat',
       },
       {
         type: 'autocomplete',
@@ -83,7 +86,7 @@ credential
     credentialSubject[type] = answers.claimValue
 
     const credential: CredentialPayload = {
-      issuer: { id: answers.iss },
+      issuer: { id: issuersQuery.iss },
       '@context': ['https://www.w3.org/2018/credentials/v1', 'https://veramo.io/contexts/profile/v1'],
       type: answers.type.split(','),
       issuanceDate: new Date().toISOString(),

--- a/packages/credential-w3c/src/__tests__/action-handler.test.ts
+++ b/packages/credential-w3c/src/__tests__/action-handler.test.ts
@@ -192,7 +192,7 @@ describe('@veramo/credential-w3c', () => {
         credential: { dummy: 'data', issuer: { id: didKeyIdentifier.did } },
         proofFormat: 'unknown',
       }),
-    ).rejects.toThrow(/invalid_setup: No issuer found for the requested proof format/)
+    ).rejects.toThrow(/invalid_setup: No provider found for the requested proof format/)
   })
 
   it('fails to create presentation with unknown proof format', async () => {
@@ -202,6 +202,6 @@ describe('@veramo/credential-w3c', () => {
         presentation: { dummy: 'data', holder: didKeyIdentifier.did },
         proofFormat: 'unknown',
       }),
-    ).rejects.toThrow(/invalid_setup: No issuer found for the requested proof format/)
+    ).rejects.toThrow(/invalid_setup: No provider found for the requested proof format/)
   })
 })

--- a/packages/credential-w3c/src/action-handler.ts
+++ b/packages/credential-w3c/src/action-handler.ts
@@ -43,10 +43,10 @@ export class CredentialPlugin implements IAgentPlugin {
       },
     },
   }
-  private issuers: ICredentialProvider[]
+  private providers: ICredentialProvider[]
 
-  constructor(issuers: ICredentialProvider[]) {
-    this.issuers = issuers
+  constructor(providers: ICredentialProvider[]) {
+    this.providers = providers
     this.methods = {
       listUsableProofFormats: this.listUsableProofFormats.bind(this),
       createVerifiableCredential: this.createVerifiableCredential.bind(this),
@@ -61,8 +61,8 @@ export class CredentialPlugin implements IAgentPlugin {
     const signingOptions: string[] = []
     const keys = did.keys
     for (const key of keys) {
-      for (const issuer of this.issuers) {
-        signingOptions.push(...issuer.getProofFormatsSupportedForKey(key))
+      for (const provider of this.providers) {
+        signingOptions.push(...provider.getProofFormatsSupportedForKey(key))
       }
     }
     return signingOptions
@@ -104,14 +104,14 @@ export class CredentialPlugin implements IAgentPlugin {
     try {
       let verifiableCredential: VerifiableCredential | undefined
 
-      async function tryToIssueCredential(issuers: ICredentialProvider[]) {
-        for (const issuer of issuers) {
-          if (issuer.canIssueProofFormat({ proofFormat })) {
-            return await issuer.createVerifiableCredential(args, context)
+      async function tryToIssueCredential(providers: ICredentialProvider[]) {
+        for (const provider of providers) {
+          if (provider.canIssueProofFormat({ proofFormat })) {
+            return await provider.createVerifiableCredential(args, context)
           }
         }
       }
-      verifiableCredential = await tryToIssueCredential(this.issuers)
+      verifiableCredential = await tryToIssueCredential(this.providers)
 
       if (!verifiableCredential) {
         throw new Error('invalid_setup: No issuer found for the requested proof format')
@@ -139,7 +139,7 @@ export class CredentialPlugin implements IAgentPlugin {
         }
       }
     }
-    let verificationResult = await getVerificationResult(this.issuers)
+    let verificationResult = await getVerificationResult(this.providers)
     if (!verificationResult) {
       throw new Error('invalid_setup: No verifier found for the provided credential')
     }
@@ -198,7 +198,7 @@ export class CredentialPlugin implements IAgentPlugin {
       }
     }
 
-    let verifiablePresentation = await tryToCreatePresentation(this.issuers)
+    let verifiablePresentation = await tryToCreatePresentation(this.providers)
 
     if (!verifiablePresentation) {
       throw new Error('invalid_setup: No issuer found for the requested proof format')
@@ -222,7 +222,7 @@ export class CredentialPlugin implements IAgentPlugin {
         }
       }
     }
-    let result = await tryVerification(this.issuers)
+    let result = await tryVerification(this.providers)
     if (!result) {
       throw new Error('invalid_setup: No verifier found for the provided presentation')
     }

--- a/packages/credential-w3c/src/action-handler.ts
+++ b/packages/credential-w3c/src/action-handler.ts
@@ -114,7 +114,7 @@ export class CredentialPlugin implements IAgentPlugin {
       verifiableCredential = await tryToIssueCredential(this.providers)
 
       if (!verifiableCredential) {
-        throw new Error('invalid_setup: No issuer found for the requested proof format')
+        throw new Error('invalid_setup: No provider found for the requested proof format')
       }
 
       if (save) {
@@ -201,7 +201,7 @@ export class CredentialPlugin implements IAgentPlugin {
     let verifiablePresentation = await tryToCreatePresentation(this.providers)
 
     if (!verifiablePresentation) {
-      throw new Error('invalid_setup: No issuer found for the requested proof format')
+      throw new Error('invalid_setup: No provider found for the requested proof format')
     }
 
     if (save) {


### PR DESCRIPTION
## What issue is this PR fixing

In #1488 and #1395 the CredentialPlugin setup has been updated.
The `@veramo/cli` package default configuration needs to be kept up to date.

This also adapts the `veramo credential create` example to use the relevant proof formats based on the agent.yml config.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because no tests are available yet for the cli package, and I am aware that a PR without tests will likely get rejected.

## Details
In the CLI example, `veramo credential create` first asks for the issuer, then uses that to pick the available proof formats.