### PR TITLE
refactor(did-manager): DID operations use `localOnly` flag instead of `isLocal`

### DIFF
--- a/__tests__/shared/didManager.ts
+++ b/__tests__/shared/didManager.ts
@@ -441,7 +441,7 @@ export default (testContext: {
       const result = await agent.didManagerAddKey({
         did: webIdentifier.did,
         key: localKey,
-        options: { isLocal: true },
+        options: { localOnly: true },
       })
 
       expect(result).toEqual(true)
@@ -458,7 +458,7 @@ export default (testContext: {
       const result = await agent.didManagerRemoveKey({
         did: webIdentifier.did,
         kid: localKey.kid,
-        options: { isLocal: true },
+        options: { localOnly: true },
       })
 
       expect(result).toEqual(true)
@@ -482,7 +482,7 @@ export default (testContext: {
       const result = await agent.didManagerAddService({
         did: webIdentifier.did,
         service: mockService,
-        options: { isLocal: true },
+        options: { localOnly: true },
       })
 
       expect(result).toEqual(true)
@@ -491,7 +491,7 @@ export default (testContext: {
       expect(updatedIdentifier.services.some((service: any) => service.id === mockService.id)).toBe(true)
     })
 
-    it('should remove service from identifier with isLocal=true', async () => {
+    it('should remove service from identifier with localOnly=true', async () => {
       const webIdentifier = await agent.didManagerGet({
         did: 'did:web:did.example.com',
       })
@@ -502,7 +502,7 @@ export default (testContext: {
       const result = await agent.didManagerRemoveService({
         did: webIdentifier.did,
         id: mockService.id,
-        options: { isLocal: true },
+        options: { localOnly: true },
       })
 
       expect(result).toEqual(true)

--- a/packages/core-types/src/plugin.schema.ts
+++ b/packages/core-types/src/plugin.schema.ts
@@ -794,7 +794,7 @@ export const schema = {
               "description": "Optional. Key metadata. This should be used to determine which algorithms are supported."
             }
           },
-          "description": "Represents an object type where a subset of keys are required and everything else is optional."
+          "description": "Represents an object type where a subset of keys is required and everything else is optional."
         },
         "IKeyManagerSharedSecretArgs": {
           "type": "object",
@@ -1067,11 +1067,13 @@ export const schema = {
             "options": {
               "type": "object",
               "properties": {
-                "isLocal": {
-                  "type": "boolean"
+                "localOnly": {
+                  "type": "boolean",
+                  "description": "Optional flag to indicate that the key should only be added to the local DIDStore tracking and this update will not be published to any underlying registries",
+                  "default": false
                 }
               },
-              "description": "Optional. Identifier provider specific options"
+              "description": "Optional. Identifier-provider specific options"
             }
           },
           "required": [
@@ -1157,11 +1159,13 @@ export const schema = {
             "options": {
               "type": "object",
               "properties": {
-                "isLocal": {
-                  "type": "boolean"
+                "localOnly": {
+                  "type": "boolean",
+                  "description": "Optional flag to indicate that the service should only be added to the local DIDStore tracking and this update will not be published to any underlying registries",
+                  "default": false
                 }
               },
-              "description": "Optional. Identifier provider specific options"
+              "description": "Optional. Identifier-provider specific options"
             }
           },
           "required": [
@@ -1235,7 +1239,7 @@ export const schema = {
             },
             "options": {
               "type": "object",
-              "description": "Optional. Identifier provider specific options"
+              "description": "Optional. Identifier-provider specific options"
             }
           },
           "description": "Input arguments for  {@link IDIDManager.didManagerCreate | didManagerCreate }"
@@ -1356,7 +1360,7 @@ export const schema = {
             },
             "options": {
               "type": "object",
-              "description": "Optional. Identifier provider specific options"
+              "description": "Optional. Identifier-provider specific options"
             }
           },
           "required": [
@@ -1442,7 +1446,7 @@ export const schema = {
               "description": "Optional. Key metadata. This should be used to determine which algorithms are supported."
             }
           },
-          "description": "Represents an object type where a subset of keys are required and everything else is optional."
+          "description": "Represents an object type where a subset of keys is required and everything else is optional."
         },
         "IDIDManagerRemoveKeyArgs": {
           "type": "object",
@@ -1458,11 +1462,13 @@ export const schema = {
             "options": {
               "type": "object",
               "properties": {
-                "isLocal": {
-                  "type": "boolean"
+                "localOnly": {
+                  "type": "boolean",
+                  "description": "Optional flag to indicate that the key should only be removed from the local DIDStore tracking and this update will not be published to any underlying registries",
+                  "default": false
                 }
               },
-              "description": "Optional. Identifier provider specific options"
+              "description": "Optional. Identifier-provider specific options"
             }
           },
           "required": [
@@ -1485,11 +1491,13 @@ export const schema = {
             "options": {
               "type": "object",
               "properties": {
-                "isLocal": {
-                  "type": "boolean"
+                "localOnly": {
+                  "type": "boolean",
+                  "description": "Optional flag to indicate that the service should only be removed from the local DIDStore tracking and this update will not be published to any underlying registries",
+                  "default": false
                 }
               },
-              "description": "Optional. Identifier provider specific options"
+              "description": "Optional. Identifier-provider specific options"
             }
           },
           "required": [
@@ -1742,6 +1750,13 @@ export const schema = {
             },
             "options": {
               "type": "object",
+              "properties": {
+                "localOnly": {
+                  "type": "boolean",
+                  "description": "Optional flag to indicate that the changes will only be applied to the local DIDStore tracking and this update will not be published to any underlying registries AbstractIdentifierProvider implementations must respect this flag where applicable. Defaults to false.",
+                  "default": false
+                }
+              },
               "description": "Identifier provider specific options."
             }
           },

--- a/packages/core-types/src/types/IDIDManager.ts
+++ b/packages/core-types/src/types/IDIDManager.ts
@@ -1,6 +1,6 @@
 import { DIDDocument } from 'did-resolver'
-import { IPluginMethodMap, IAgentContext } from './IAgent.js'
-import { IIdentifier, IService, IKey, MinimalImportableIdentifier } from './IIdentifier.js'
+import { IAgentContext, IPluginMethodMap } from './IAgent.js'
+import { IIdentifier, IKey, IService, MinimalImportableIdentifier } from './IIdentifier.js'
 import { IKeyManager } from './IKeyManager.js'
 
 /**
@@ -78,7 +78,7 @@ export interface IDIDManagerCreateArgs {
   kms?: string
 
   /**
-   * Optional. Identifier provider specific options
+   * Optional. Identifier-provider specific options
    */
   options?: object
 }
@@ -120,7 +120,7 @@ export interface IDIDManagerGetOrCreateArgs {
   kms?: string
 
   /**
-   * Optional. Identifier provider specific options
+   * Optional. Identifier-provider specific options
    */
   options?: object
 }
@@ -149,6 +149,12 @@ export interface IDIDManagerUpdateArgs {
    * @see {@link @veramo/did-manager#AbstractIdentifierProvider | AbstractIdentifierProvider}
    */
   options?: {
+    /**
+     * Optional flag to indicate that the changes will only be applied to the local DIDStore tracking and this update will not be published to any underlying registries
+     * AbstractIdentifierProvider implementations must respect this flag where applicable. Defaults to false.
+     * @default false
+     */
+    localOnly?: boolean
     [x: string]: any
   }
 }
@@ -169,10 +175,14 @@ export interface IDIDManagerAddKeyArgs {
   key: IKey
 
   /**
-   * Optional. Identifier provider specific options
+   * Optional. Identifier-provider specific options
    */
   options?: {
-    isLocal?: boolean
+    /**
+     * Optional flag to indicate that the key should only be added to the local DIDStore tracking and this update will not be published to any underlying registries
+     * @default false
+     */
+    localOnly?: boolean
     [key: string]: any
   }
 }
@@ -193,10 +203,14 @@ export interface IDIDManagerRemoveKeyArgs {
   kid: string
 
   /**
-   * Optional. Identifier provider specific options
+   * Optional. Identifier-provider specific options
    */
   options?: {
-    isLocal?: boolean
+    /**
+     * Optional flag to indicate that the key should only be removed from the local DIDStore tracking and this update will not be published to any underlying registries
+     * @default false
+     */
+    localOnly?: boolean
     [key: string]: any
   }
 }
@@ -217,10 +231,14 @@ export interface IDIDManagerAddServiceArgs {
   service: IService
 
   /**
-   * Optional. Identifier provider specific options
+   * Optional. Identifier-provider specific options
    */
   options?: {
-    isLocal?: boolean
+    /**
+     * Optional flag to indicate that the service should only be added to the local DIDStore tracking and this update will not be published to any underlying registries
+     * @default false
+     */
+    localOnly?: boolean
     [key: string]: any
   }
 }
@@ -241,10 +259,14 @@ export interface IDIDManagerRemoveServiceArgs {
   id: string
 
   /**
-   * Optional. Identifier provider specific options
+   * Optional. Identifier-provider specific options
    */
   options?: {
-    isLocal?: boolean
+    /**
+     * Optional flag to indicate that the service should only be removed from the local DIDStore tracking and this update will not be published to any underlying registries
+     * @default false
+     */
+    localOnly?: boolean
     [key: string]: any
   }
 }

--- a/packages/core-types/src/types/IKeyManager.ts
+++ b/packages/core-types/src/types/IKeyManager.ts
@@ -2,7 +2,7 @@ import { IPluginMethodMap } from './IAgent.js'
 import { TKeyType, IKey, KeyMetadata } from './IIdentifier.js'
 
 /**
- * Represents an object type where a subset of keys are required and everything else is optional.
+ * Represents an object type where a subset of keys is required and everything else is optional.
  *
  * @public
  */

--- a/packages/did-manager/src/abstract-identifier-provider.ts
+++ b/packages/did-manager/src/abstract-identifier-provider.ts
@@ -1,4 +1,16 @@
-import { IIdentifier, IKey, IService, IAgentContext, IKeyManager, DIDDocument } from '@veramo/core-types'
+import {
+  IIdentifier,
+  IKey,
+  IService,
+  IAgentContext,
+  IKeyManager,
+  DIDDocument,
+  IDIDManagerUpdateArgs,
+  IDIDManagerAddKeyArgs,
+  IDIDManagerRemoveKeyArgs,
+  IDIDManagerAddServiceArgs,
+  IDIDManagerRemoveServiceArgs,
+} from '@veramo/core-types'
 
 /**
  * An abstract class for the {@link @veramo/did-manager#DIDManager} identifier providers
@@ -11,29 +23,29 @@ export abstract class AbstractIdentifierProvider {
   ): Promise<Omit<IIdentifier, 'provider'>>
 
   abstract updateIdentifier?(
-    args: { did: string, document: Partial<DIDDocument>, options?: { [x: string]: any } },
+    args: { did: string, document: Partial<DIDDocument>, options?: IDIDManagerUpdateArgs['options'] },
     context: IAgentContext<IKeyManager>,
   ): Promise<IIdentifier>
 
   abstract deleteIdentifier(args: IIdentifier, context: IAgentContext<IKeyManager>): Promise<boolean>
 
   abstract addKey(
-    args: { identifier: IIdentifier; key: IKey; options?: any },
+    args: { identifier: IIdentifier; key: IKey; options?: IDIDManagerAddKeyArgs['options'] },
     context: IAgentContext<IKeyManager>,
   ): Promise<any>
 
   abstract removeKey(
-    args: { identifier: IIdentifier; kid: string; options?: any },
+    args: { identifier: IIdentifier; kid: string; options?: IDIDManagerRemoveKeyArgs['options'] },
     context: IAgentContext<IKeyManager>,
   ): Promise<any>
 
   abstract addService(
-    args: { identifier: IIdentifier; service: IService; options?: any },
+    args: { identifier: IIdentifier; service: IService; options?: IDIDManagerAddServiceArgs['options'] },
     context: IAgentContext<IKeyManager>,
   ): Promise<any>
 
   abstract removeService(
-    args: { identifier: IIdentifier; id: string; options?: any },
+    args: { identifier: IIdentifier; id: string; options?: IDIDManagerRemoveServiceArgs['options'] },
     context: IAgentContext<IKeyManager>,
   ): Promise<any>
 

--- a/packages/did-manager/src/id-manager.ts
+++ b/packages/did-manager/src/id-manager.ts
@@ -170,6 +170,7 @@ export class DIDManager implements IAgentPlugin {
         `not_supported: ${identifier?.provider} provider does not implement full document updates`,
       )
     }
+    // the localOnly Flag must be interpreted by the identifierProvider
     const updatedIdentifier = await identifierProvider.updateIdentifier({ did, document, options }, context)
     await this.store.importDID(updatedIdentifier)
     return updatedIdentifier
@@ -224,7 +225,7 @@ export class DIDManager implements IAgentPlugin {
     const identifier = await this.store.getDID({ did })
     const provider = this.getProvider(identifier.provider)
     let result = true
-    if (!options?.isLocal) {
+    if (!options?.localOnly) {
       result = await provider.addKey({ identifier, key, options }, context)
     }
     identifier.keys.push(key)
@@ -240,7 +241,7 @@ export class DIDManager implements IAgentPlugin {
     const identifier = await this.store.getDID({ did })
     const provider = this.getProvider(identifier.provider)
     let result = true
-    if (!options?.isLocal) {
+    if (!options?.localOnly) {
       result = await provider.removeKey({ identifier, kid, options }, context)
     }
     identifier.keys = identifier.keys.filter((k) => k.kid !== kid)
@@ -256,7 +257,7 @@ export class DIDManager implements IAgentPlugin {
     const identifier = await this.store.getDID({ did })
     const provider = this.getProvider(identifier.provider)
     let result = true
-    if (!options?.isLocal) {
+    if (!options?.localOnly) {
       result = await provider.addService({ identifier, service, options }, context)
     }
     identifier.services.push(service)
@@ -272,7 +273,7 @@ export class DIDManager implements IAgentPlugin {
     const identifier = await this.store.getDID({ did })
     const provider = this.getProvider(identifier.provider)
     let result = true
-    if (!options?.isLocal) {
+    if (!options?.localOnly) {
       result = await provider.removeService({ identifier, id, options }, context)
     }
     identifier.services = identifier.services.filter((s) => s.id !== id)


### PR DESCRIPTION
## What issue is this PR fixing

This flag can be used to perform updates only to the local DIDStore without publishing updates to underlying registries. See also #1452
This is a rename of the `isLocal` flag to align better with existing flags (like `signOnly` from did-provider-ethr)

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [ ] I did not add automated tests because _________, and I am aware that a PR without tests will likely get rejected.

## Details
If applicable, add screen captures, error messages or stack traces to help explain your problem.
