### PR TITLE
fix(key-manager): handling of `kid` param when creating keys

### DIFF
--- a/packages/did-provider-pkh/src/pkh-did-provider.ts
+++ b/packages/did-provider-pkh/src/pkh-did-provider.ts
@@ -1,43 +1,37 @@
-import { computeAddress } from 'ethers';
-import {
-  IAgentContext,
-  IIdentifier,
-  IKey,
-  IKeyManager,
-  IService,
-} from '@veramo/core-types';
+import { computeAddress } from 'ethers'
+import { IAgentContext, IIdentifier, IKey, IKeyManager, IService } from '@veramo/core-types'
 
-import { AbstractIdentifierProvider } from '@veramo/did-manager';
-import { importOrCreateKey, CreateIdentifierBaseOptions } from '@veramo/utils';
+import { AbstractIdentifierProvider } from '@veramo/did-manager'
+import { importOrCreateKey, CreateIdentifierBaseOptions } from '@veramo/utils'
 import Debug from 'debug'
 
 const debug = Debug('veramo:pkh-did-provider')
 
-type IContext = IAgentContext<IKeyManager>;
+type IContext = IAgentContext<IKeyManager>
 
 const isIn = <T>(values: readonly T[], value: any): value is T => {
-  return values.includes(value);
-};
+  return values.includes(value)
+}
 
-export const SECPK1_NAMESPACES = ['eip155'] as const;
-export const isValidNamespace = (x: string) => isIn(SECPK1_NAMESPACES, x);
+export const SECPK1_NAMESPACES = ['eip155'] as const
+export const isValidNamespace = (x: string) => isIn(SECPK1_NAMESPACES, x)
 
 /**
  * Options for creating a did:pkh
  * @beta
  */
 export type CreateDidPkhOptions = CreateIdentifierBaseOptions<'Secp256k1'> & {
-  namespace: string;
+  namespace: string
   /**
    * @deprecated use key.privateKeyHex instead
    */
-  privateKey: string;
+  privateKey: string
   /**
    * This can be hex encoded chain ID (string) or a chainId number
    *
    * If this is not specified, `1` is assumed.
    */
-  chainId?: string | number;
+  chainId?: string | number
 }
 
 /**
@@ -45,10 +39,8 @@ export type CreateDidPkhOptions = CreateIdentifierBaseOptions<'Secp256k1'> & {
  * @param hexPublicKey A hex encoded public key, optionally prefixed with `0x`
  */
 export function toEthereumAddress(hexPublicKey: string): string {
-  const publicKey = hexPublicKey.startsWith('0x')
-    ? hexPublicKey
-    : '0x' + hexPublicKey;
-  return computeAddress(publicKey);
+  const publicKey = hexPublicKey.startsWith('0x') ? hexPublicKey : '0x' + hexPublicKey
+  return computeAddress(publicKey)
 }
 
 /**
@@ -57,51 +49,50 @@ export function toEthereumAddress(hexPublicKey: string): string {
  * @beta This API may change without a BREAKING CHANGE notice.
  */
 export class PkhDIDProvider extends AbstractIdentifierProvider {
-  private defaultKms: string;
-  private chainId: string;
+  private defaultKms: string
+  private chainId: string
 
   constructor(options: { defaultKms: string; chainId?: string }) {
-    super();
-    this.defaultKms = options.defaultKms;
-    this.chainId = options?.chainId ? options.chainId : '1';
+    super()
+    this.defaultKms = options.defaultKms
+    this.chainId = options?.chainId ? options.chainId : '1'
   }
 
   async createIdentifier(
     { kms, options }: { kms?: string; options?: CreateDidPkhOptions },
-    context: IContext
+    context: IContext,
   ): Promise<Omit<IIdentifier, 'provider'>> {
-    const namespace = options?.namespace ? options.namespace : 'eip155';
+    const namespace = options?.namespace ? options.namespace : 'eip155'
 
     if (!isValidNamespace(namespace)) {
-      debug(
-        `invalid_namespace: '${namespace}'. valid namespaces are: ${SECPK1_NAMESPACES}`
-      );
-      throw new Error(
-        `invalid_namespace: '${namespace}'. valid namespaces are: ${SECPK1_NAMESPACES}`
-      );
+      debug(`invalid_namespace: '${namespace}'. valid namespaces are: ${SECPK1_NAMESPACES}`)
+      throw new Error(`invalid_namespace: '${namespace}'. valid namespaces are: ${SECPK1_NAMESPACES}`)
     }
 
-    const privateKeyHex = options?.key?.privateKeyHex || options?.privateKey;
+    const privateKeyHex = options?.key?.privateKeyHex || options?.privateKey
     let key: IKey
 
     if (options?.keyRef) {
-      key = await context.agent.keyManagerGet({ kid: options.keyRef });
+      key = await context.agent.keyManagerGet({ kid: options.keyRef })
 
       if (key.type !== 'Secp256k1') {
-        throw new Error(`not_supported: Key type must be Secp256k1`  );
+        throw new Error(`not_supported: Key type must be Secp256k1`)
       }
     } else {
-      key = await importOrCreateKey({
-        kms: kms || this.defaultKms,
-        options: {
-          ...(options?.key ?? {}),
-          type: 'Secp256k1',
-          privateKeyHex,
+      key = await importOrCreateKey(
+        {
+          kms: kms || this.defaultKms,
+          options: {
+            ...(options?.key ?? {}),
+            type: 'Secp256k1',
+            privateKeyHex,
+          },
         },
-      }, context);
+        context,
+      )
     }
 
-    const evmAddress: string = toEthereumAddress(key.publicKeyHex);
+    const evmAddress: string = toEthereumAddress(key.publicKeyHex)
 
     if (key !== null) {
       const identifier: Omit<IIdentifier, 'provider'> = {
@@ -109,71 +100,58 @@ export class PkhDIDProvider extends AbstractIdentifierProvider {
         controllerKeyId: key.kid,
         keys: [key],
         services: [],
-      };
-      return identifier;
+      }
+      return identifier
     } else {
-      debug('Could not create identifier due to some errors');
-      throw new Error('unknown_error: could not create identifier due to errors creating or importing keys');
+      debug('Could not create identifier due to some errors')
+      throw new Error('unknown_error: could not create identifier due to errors creating or importing keys')
     }
   }
 
   async updateIdentifier(
     args: {
-      did: string;
-      kms?: string | undefined;
-      alias?: string | undefined;
-      options?: any;
+      did: string
+      kms?: string | undefined
+      alias?: string | undefined
+      options?: any
     },
-    context: IAgentContext<IKeyManager>
+    context: IAgentContext<IKeyManager>,
   ): Promise<IIdentifier> {
-    throw new Error('illegal_operation: did:pkh update is not possible.');
+    throw new Error('illegal_operation: did:pkh update is not possible.')
   }
 
-  async deleteIdentifier(
-    identifier: IIdentifier,
-    context: IContext
-  ): Promise<boolean> {
+  async deleteIdentifier(identifier: IIdentifier, context: IContext): Promise<boolean> {
     for (const { kid } of identifier.keys) {
-      await context.agent.keyManagerDelete({ kid });
+      await context.agent.keyManagerDelete({ kid })
     }
-    return true;
+    return true
   }
 
   async addKey(
-    {
-      identifier,
-      key,
-      options,
-    }: { identifier: IIdentifier; key: IKey; options?: any },
-    context: IContext
+    { identifier, key, options }: { identifier: IIdentifier; key: IKey; options?: any },
+    context: IContext,
   ): Promise<any> {
-    throw Error('illegal_operation: did:pkh addKey is not possible.');
+    throw Error('illegal_operation: did:pkh addKey is not possible.')
   }
 
   async addService(
-    {
-      identifier,
-      service,
-      options,
-    }: { identifier: IIdentifier; service: IService; options?: any },
-    context: IContext
+    { identifier, service, options }: { identifier: IIdentifier; service: IService; options?: any },
+    context: IContext,
   ): Promise<any> {
-    throw Error('illegal_operation: did:pkh addService is not possible.');
+    throw Error('illegal_operation: did:pkh addService is not possible.')
   }
 
   async removeKey(
     args: { identifier: IIdentifier; kid: string; options?: any },
-    context: IContext
+    context: IContext,
   ): Promise<any> {
-    throw Error('illegal_operation: did:pkh removeKey is not possible.');
-
+    throw Error('illegal_operation: did:pkh removeKey is not possible.')
   }
 
   async removeService(
     args: { identifier: IIdentifier; id: string; options?: any },
-    context: IContext
+    context: IContext,
   ): Promise<any> {
-    throw Error('illegal_operation: did:pkh removeService is not possible.');
-
+    throw Error('illegal_operation: did:pkh removeService is not possible.')
   }
 }

--- a/packages/did-provider-web/src/web-did-provider.ts
+++ b/packages/did-provider-web/src/web-did-provider.ts
@@ -37,7 +37,6 @@ export class WebDIDProvider extends AbstractIdentifierProvider {
 
     if (options?.keyRef) {
       key = await context.agent.keyManagerGet({ kid: options.keyRef })
-      keyType = key.type;
     } else {
       key = await importOrCreateKey(
         {

--- a/packages/key-manager/src/__tests__/default.test.ts
+++ b/packages/key-manager/src/__tests__/default.test.ts
@@ -1,6 +1,47 @@
+import { KeyManager, MemoryKeyStore, MemoryPrivateKeyStore } from '../index.js'
+import { KeyManagementSystem } from '../../../kms-local/src/index.js'
+
 describe('key-manager', () => {
-  const a = 100
-  it('should run a dummy test', () => {
-    expect(a).toEqual(100)
+  it('creates a key and signs with it', async () => {
+    const kms = new KeyManagementSystem(new MemoryPrivateKeyStore())
+    const keyManager = new KeyManager({
+      store: new MemoryKeyStore(),
+      kms: { local: kms },
+    })
+
+    const key = await keyManager.keyManagerCreate({ type: 'Ed25519', kms: 'local', kid: 'test-key' })
+    expect(key.type).toEqual('Ed25519')
+    expect(key.kid).toEqual('test-key')
+    expect(key.kms).toEqual('local')
+
+    const data = 'test data for signing'
+    const signature = await keyManager.keyManagerSign({ keyRef: 'test-key', data, algorithm: 'EdDSA' })
+    expect(signature).toBeDefined()
+    expect(typeof signature).toBe('string')
+  })
+
+  it('imports a key and signs with it', async () => {
+    const kms = new KeyManagementSystem(new MemoryPrivateKeyStore())
+    const keyManager = new KeyManager({
+      store: new MemoryKeyStore(),
+      kms: { local: kms },
+    })
+
+    const privateKeyHex = 'ed3991fa33d4df22c88b78249e4d73c509c640a873a66808ad5dce774334ce94ee5072bc20355b4cd5499e04ee70853591bffa1874b1b5467dedd648d5b89ecb'
+    const key = await keyManager.keyManagerImport({
+      kid: 'imported-key',
+      type: 'Ed25519',
+      privateKeyHex,
+      kms: 'local',
+    })
+    expect(key.type).toEqual('Ed25519')
+    expect(key.kid).toEqual('imported-key')
+    expect(key.kms).toEqual('local')
+
+
+    const data = 'test data for signing'
+    const signature = await keyManager.keyManagerSign({ keyRef: 'imported-key', data, algorithm: 'EdDSA' })
+    expect(signature).toBeDefined()
+    expect(typeof signature).toBe('string')
   })
 })

--- a/packages/key-manager/src/__tests__/default.test.ts
+++ b/packages/key-manager/src/__tests__/default.test.ts
@@ -1,47 +1,218 @@
-import { KeyManager, MemoryKeyStore, MemoryPrivateKeyStore } from '../index.js'
-import { KeyManagementSystem } from '../../../kms-local/src/index.js'
+import { AbstractKeyManagementSystem, KeyManager, MemoryKeyStore } from '../index.js'
+import { IKey, ManagedKeyInfo, MinimalImportableKey, TKeyType } from '../../../core-types/src'
+
+const TEST_KEY_TYPE = 'TEST_KEY_TYPE'
+const TEST_ALG = 'TEST_ALG'
+
+class DummyKMS extends AbstractKeyManagementSystem {
+  private keys: Map<string, ManagedKeyInfo> = new Map()
+
+  async importKey(args: Exclude<MinimalImportableKey, 'kms'>): Promise<ManagedKeyInfo> {
+    if (args.type && args.type !== TEST_KEY_TYPE) {
+      throw new Error('not_supported: Only TEST_KEY_TYPE is supported')
+    }
+    const key: ManagedKeyInfo = {
+      type: args.type ?? TEST_KEY_TYPE,
+      kid: args.kid || 'dummy-kid',
+      publicKeyHex: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      kms: 'dummy',
+      meta: { algorithms: [TEST_ALG] },
+    }
+    this.keys.set(key.kid, key)
+    return key
+  }
+
+  async listKeys(): Promise<ManagedKeyInfo[]> {
+    return Array.from(this.keys.values())
+  }
+
+  async createKey({ type, kid }: { type: TKeyType; kid?: string }): Promise<ManagedKeyInfo> {
+    if (type && type !== TEST_KEY_TYPE) {
+      throw new Error('not_supported: Only TEST_KEY_TYPE is supported')
+    }
+    const key: ManagedKeyInfo = {
+      type: type ?? TEST_KEY_TYPE,
+      kid: kid ? `${kid}-but-changed-by-the-kms` : 'dummy-key-' + Math.random(),
+      publicKeyHex: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      kms: 'dummy',
+      meta: { algorithms: [TEST_ALG] },
+    }
+    this.keys.set(key.kid, key)
+    return key
+  }
+
+  async deleteKey({ kid }: { kid: string }): Promise<boolean> {
+    return this.keys.delete(kid)
+  }
+
+  async sign({
+    keyRef,
+    algorithm,
+    data,
+  }: {
+    keyRef: Pick<IKey, 'kid'>
+    algorithm?: string
+    data: Uint8Array
+  }): Promise<string> {
+    if (algorithm && algorithm !== TEST_ALG) {
+      throw new Error('not_supported: Only TEST_ALG is supported')
+    }
+    if (!this.keys.has(keyRef.kid)) {
+      throw new Error(`key_not_found: Key with kid ${keyRef.kid} not found`)
+    }
+    return 'dummy-signature-' + data.length
+  }
+
+  async sharedSecret({
+    myKeyRef,
+    theirKey,
+  }: {
+    myKeyRef: Pick<IKey, 'kid'>
+    theirKey: Pick<IKey, 'publicKeyHex' | 'type'>
+  }): Promise<string> {
+    if (!this.keys.has(myKeyRef.kid)) {
+      throw new Error(`key_not_found: Key with kid ${myKeyRef.kid} not found`)
+    }
+    return '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+  }
+}
 
 describe('key-manager', () => {
   it('creates a key and signs with it', async () => {
-    const kms = new KeyManagementSystem(new MemoryPrivateKeyStore())
+    const kms = new DummyKMS()
     const keyManager = new KeyManager({
       store: new MemoryKeyStore(),
-      kms: { local: kms },
+      kms: { dummy: kms },
     })
 
-    const key = await keyManager.keyManagerCreate({ type: 'Ed25519', kms: 'local', kid: 'test-key' })
-    expect(key.type).toEqual('Ed25519')
-    expect(key.kid).toEqual('test-key')
-    expect(key.kms).toEqual('local')
+    const key = await keyManager.keyManagerCreate({ type: TEST_KEY_TYPE, kms: 'dummy', kid: 'test-key' })
+    expect(key.type).toEqual(TEST_KEY_TYPE)
+    expect(key.kid).toEqual('test-key-but-changed-by-the-kms')
+    expect(key.kms).toEqual('dummy')
 
     const data = 'test data for signing'
-    const signature = await keyManager.keyManagerSign({ keyRef: 'test-key', data, algorithm: 'EdDSA' })
+    const signature = await keyManager.keyManagerSign({ keyRef: key.kid, data, algorithm: TEST_ALG })
     expect(signature).toBeDefined()
     expect(typeof signature).toBe('string')
   })
 
   it('imports a key and signs with it', async () => {
-    const kms = new KeyManagementSystem(new MemoryPrivateKeyStore())
+    const kms = new DummyKMS()
     const keyManager = new KeyManager({
       store: new MemoryKeyStore(),
-      kms: { local: kms },
+      kms: { dummy: kms },
     })
 
-    const privateKeyHex = 'ed3991fa33d4df22c88b78249e4d73c509c640a873a66808ad5dce774334ce94ee5072bc20355b4cd5499e04ee70853591bffa1874b1b5467dedd648d5b89ecb'
+    const privateKeyHex = 'dummy-private-key-hex'
     const key = await keyManager.keyManagerImport({
       kid: 'imported-key',
-      type: 'Ed25519',
+      type: TEST_KEY_TYPE,
       privateKeyHex,
-      kms: 'local',
+      kms: 'dummy',
     })
-    expect(key.type).toEqual('Ed25519')
+    expect(key.type).toEqual(TEST_KEY_TYPE)
     expect(key.kid).toEqual('imported-key')
-    expect(key.kms).toEqual('local')
-
+    expect(key.kms).toEqual('dummy')
 
     const data = 'test data for signing'
-    const signature = await keyManager.keyManagerSign({ keyRef: 'imported-key', data, algorithm: 'EdDSA' })
+    const signature = await keyManager.keyManagerSign({ keyRef: 'imported-key', data, algorithm: TEST_ALG })
     expect(signature).toBeDefined()
     expect(typeof signature).toBe('string')
+  })
+
+  it('gets key management systems', async () => {
+    const kms = new DummyKMS()
+    const keyManager = new KeyManager({
+      store: new MemoryKeyStore(),
+      kms: { local: kms, dummy: kms },
+    })
+
+    const systems = await keyManager.keyManagerGetKeyManagementSystems()
+    expect(systems).toEqual(['local', 'dummy'])
+  })
+
+  it('gets a key', async () => {
+    const kms = new DummyKMS()
+    const keyManager = new KeyManager({
+      store: new MemoryKeyStore(),
+      kms: { dummy: kms },
+    })
+
+    const createdKey = await keyManager.keyManagerCreate({
+      type: TEST_KEY_TYPE,
+      kms: 'dummy',
+      kid: 'get-test-key',
+    })
+    const key = await keyManager.keyManagerGet({ kid: createdKey.kid })
+    expect(key.type).toEqual(TEST_KEY_TYPE)
+    expect(key.kms).toEqual('dummy')
+  })
+
+  it('deletes a key', async () => {
+    const kms = new DummyKMS()
+    const keyManager = new KeyManager({
+      store: new MemoryKeyStore(),
+      kms: { dummy: kms },
+    })
+
+    const key = await keyManager.keyManagerCreate({
+      type: TEST_KEY_TYPE,
+      kms: 'dummy',
+      kid: 'delete-test-key',
+    })
+    const result = await keyManager.keyManagerDelete({ kid: key.kid })
+    expect(result).toBe(true)
+
+    await expect(keyManager.keyManagerGet({ kid: key.kid })).rejects.toThrow()
+  })
+
+  it('fails to encrypt and decrypts JWE because of unsupported algorithms', async () => {
+    const kms = new DummyKMS()
+    const keyManager = new KeyManager({
+      store: new MemoryKeyStore(),
+      kms: { dummy: kms },
+    })
+
+    const senderKey = await keyManager.keyManagerCreate({ type: TEST_KEY_TYPE, kms: 'dummy', kid: 'sender' })
+    const recipientKey = {
+      type: TEST_KEY_TYPE,
+      publicKeyHex: 'dummy',
+      kid: 'recipient',
+    }
+
+    const data = 'secret message'
+    await expect(
+      keyManager.keyManagerEncryptJWE({ kid: senderKey.kid, to: recipientKey, data }),
+    ).rejects.toThrow('not_supported: The recipient public key type is not supported')
+  })
+
+  it('computes shared secret', async () => {
+    const kms = new DummyKMS()
+    const keyManager = new KeyManager({
+      store: new MemoryKeyStore(),
+      kms: { dummy: kms },
+    })
+
+    const myKey = await keyManager.keyManagerCreate({ type: TEST_KEY_TYPE, kms: 'dummy', kid: 'my-key' })
+    const theirKey = {
+      type: TEST_KEY_TYPE,
+      publicKeyHex: 'really doesnt matter for the dummy kms',
+    }
+
+    const secret = await keyManager.keyManagerSharedSecret({ secretKeyRef: myKey.kid, publicKey: theirKey })
+    expect(secret).toEqual('0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+  })
+
+  it('signs JWT', async () => {
+    const kms = new DummyKMS()
+    const keyManager = new KeyManager({
+      store: new MemoryKeyStore(),
+      kms: { dummy: kms },
+    })
+
+    const key = await keyManager.keyManagerCreate({ type: TEST_KEY_TYPE, kms: 'dummy', kid: 'jwt-key' })
+    const data = 'test jwt data'
+    const signature = await keyManager.keyManagerSignJWT({ kid: key.kid, data })
+    expect(signature).toEqual('dummy-signature-13')
   })
 })

--- a/packages/key-manager/src/abstract-key-management-system.ts
+++ b/packages/key-manager/src/abstract-key-management-system.ts
@@ -12,7 +12,7 @@ export abstract class AbstractKeyManagementSystem {
 
   abstract listKeys(): Promise<Array<ManagedKeyInfo>>
 
-  abstract createKey(args: { type: TKeyType; meta?: any }): Promise<ManagedKeyInfo>
+  abstract createKey(args: { type: TKeyType; meta?: any; kid?: string }): Promise<ManagedKeyInfo>
 
   abstract deleteKey(args: { kid: string }): Promise<boolean>
 

--- a/packages/key-manager/src/key-manager.ts
+++ b/packages/key-manager/src/key-manager.ts
@@ -15,14 +15,14 @@ import {
   IKeyManagerSignJWTArgs,
   ManagedKeyInfo,
   MinimalImportableKey,
+  schema,
   TKeyType,
 } from '@veramo/core-types'
-import { schema } from '@veramo/core-types'
 import * as u8a from 'uint8arrays'
 import { createAnonDecrypter, createAnonEncrypter, createJWE, decryptJWE, type ECDH, type JWE } from 'did-jwt'
 import { convertEd25519PublicKeyToX25519 } from '@veramo/utils'
 import Debug from 'debug'
-import { getBytes, hexlify, toUtf8Bytes, toUtf8String, computeAddress, Transaction } from 'ethers'
+import { computeAddress, getBytes, hexlify, toUtf8Bytes, toUtf8String, Transaction } from 'ethers'
 
 const debug = Debug('veramo:key-manager')
 
@@ -70,14 +70,6 @@ export class KeyManager implements IAgentPlugin {
     }
   }
 
-  private getKms(name: string): AbstractKeyManagementSystem {
-    const kms = this.kms[name]
-    if (!kms) {
-      throw Error(`invalid_argument: This agent has no registered KeyManagementSystem with name='${name}'`)
-    }
-    return kms
-  }
-
   /** {@inheritDoc @veramo/core-types#IKeyManager.keyManagerGetKeyManagementSystems} */
   async keyManagerGetKeyManagementSystems(): Promise<Array<string>> {
     return Object.keys(this.kms)
@@ -86,12 +78,8 @@ export class KeyManager implements IAgentPlugin {
   /** {@inheritDoc @veramo/core-types#IKeyManager.keyManagerCreate} */
   async keyManagerCreate(args: IKeyManagerCreateArgs): Promise<ManagedKeyInfo> {
     const kms = this.getKms(args.kms)
-    const partialKey = await kms.createKey({ type: args.type, meta: args.meta })
-    const key: IKey = {
-      ...partialKey,
-      kms: args.kms,
-      kid: args.kid ?? partialKey.kid
-    }
+    const partialKey = await kms.createKey({ type: args.type, meta: args.meta, kid: args.kid })
+    const key: IKey = { ...partialKey, kms: args.kms }
     if (args.meta || key.meta) {
       key.meta = { ...args.meta, ...key.meta }
     }
@@ -235,5 +223,13 @@ export class KeyManager implements IAgentPlugin {
       const shared = await this.keyManagerSharedSecret({ secretKeyRef, publicKey })
       return getBytes('0x' + shared)
     }
+  }
+
+  private getKms(name: string): AbstractKeyManagementSystem {
+    const kms = this.kms[name]
+    if (!kms) {
+      throw Error(`invalid_argument: This agent has no registered KeyManagementSystem with name='${name}'`)
+    }
+    return kms
   }
 }

--- a/packages/kms-local/src/__tests__/kms-local.test.ts
+++ b/packages/kms-local/src/__tests__/kms-local.test.ts
@@ -16,7 +16,7 @@ import {
 } from '@stablelib/ed25519'
 
 describe('@veramo/kms-local', () => {
-  it('should import and convert ed25519 key', async () => {
+  it('imports and convert ed25519 key', async () => {
     const kms = new KeyManagementSystem(new MemoryPrivateKeyStore())
     const privateBytes = randomBytes(32)
     const key = await kms.importKey({
@@ -35,7 +35,38 @@ describe('@veramo/kms-local', () => {
     expect(bytesToHex(xpubNoble)).toEqual(bytesToHex(xpubStable))
   })
 
-  it('should compute a shared secret Ed+Ed', async () => {
+  it('creates a key with user-provided kid and signs with it', async () => {
+    const kms = new KeyManagementSystem(new MemoryPrivateKeyStore())
+    const kid = 'my-custom-kid'
+    const key = await kms.createKey({ type: 'Ed25519', kid })
+    expect(key.type).toEqual('Ed25519')
+    expect(key.kid).toEqual(kid)
+    expect(key.publicKeyHex).toHaveLength(64)
+    expect(key.meta?.algorithms).toContain('EdDSA')
+
+    const data = stringToUtf8Bytes('test data for custom kid')
+    const signature = await kms.sign({ keyRef: key, data, algorithm: 'EdDSA' })
+    expect(signature).toBeDefined()
+    expect(typeof signature).toBe('string')
+  })
+
+  it('imports an Ed25519 key with custom kid and signs with it', async () => {
+    const kms = new KeyManagementSystem(new MemoryPrivateKeyStore())
+    const privateKeyHex = 'ed3991fa33d4df22c88b78249e4d73c509c640a873a66808ad5dce774334ce94ee5072bc20355b4cd5499e04ee70853591bffa1874b1b5467dedd648d5b89ecb'
+    const kid = 'custom-ed25519-kid'
+    const key = await kms.importKey({ kid, privateKeyHex, type: 'Ed25519' })
+    expect(key.type).toEqual('Ed25519')
+    expect(key.kid).toEqual(kid)
+    expect(key.publicKeyHex).toHaveLength(64)
+    expect(key.meta?.algorithms).toContain('EdDSA')
+
+    const data = stringToUtf8Bytes('test data for imported Ed25519')
+    const signature = await kms.sign({ keyRef: key, data, algorithm: 'EdDSA' })
+    expect(signature).toBeDefined()
+    expect(typeof signature).toBe('string')
+  })
+
+  it('computes a shared secret Ed+Ed', async () => {
     const kms = new KeyManagementSystem(new MemoryPrivateKeyStore())
     const myKey = {
       type: <TKeyType>'Ed25519',
@@ -51,7 +82,7 @@ describe('@veramo/kms-local', () => {
     expect(secret).toEqual('2f1d171ad32fdbd10d1b06600d70223f7298809d4a3690fa03d6b4688c7b116a')
   })
 
-  it('should compute a shared secret Ed+X', async () => {
+  it('computes a shared secret Ed+X', async () => {
     const kms = new KeyManagementSystem(new MemoryPrivateKeyStore())
     const myKey = {
       type: <TKeyType>'Ed25519',
@@ -67,7 +98,7 @@ describe('@veramo/kms-local', () => {
     expect(secret).toEqual('2f1d171ad32fdbd10d1b06600d70223f7298809d4a3690fa03d6b4688c7b116a')
   })
 
-  it('should compute a shared secret X+Ed', async () => {
+  it('computes a shared secret X+Ed', async () => {
     const kms = new KeyManagementSystem(new MemoryPrivateKeyStore())
     const myKey = {
       type: <TKeyType>'X25519',
@@ -83,7 +114,7 @@ describe('@veramo/kms-local', () => {
     expect(secret).toEqual('2f1d171ad32fdbd10d1b06600d70223f7298809d4a3690fa03d6b4688c7b116a')
   })
 
-  it('should compute a shared secret X+X', async () => {
+  it('computes a shared secret X+X', async () => {
     const kms = new KeyManagementSystem(new MemoryPrivateKeyStore())
     const myKey = {
       type: <TKeyType>'X25519',
@@ -99,7 +130,7 @@ describe('@veramo/kms-local', () => {
     expect(secret).toEqual('2f1d171ad32fdbd10d1b06600d70223f7298809d4a3690fa03d6b4688c7b116a')
   })
 
-  it('should throw on invalid myKey type', async () => {
+  it('throws on invalid myKey type', async () => {
     expect.assertions(1)
     const kms = new KeyManagementSystem(new MemoryPrivateKeyStore())
     const myKey = {
@@ -115,7 +146,7 @@ describe('@veramo/kms-local', () => {
     expect(kms.sharedSecret({ myKeyRef, theirKey })).rejects.toThrow('not_supported')
   })
 
-  it('should throw on invalid theirKey type', async () => {
+  it('throws on invalid theirKey type', async () => {
     expect.assertions(1)
     const kms = new KeyManagementSystem(new MemoryPrivateKeyStore())
     const myKey = {
@@ -133,7 +164,7 @@ describe('@veramo/kms-local', () => {
 })
 
 describe('@veramo/kms-local Secp256r1 support', () => {
-  it('should generate a managed key', async () => {
+  it('generates a managed key', async () => {
     const kms = new KeyManagementSystem(new MemoryPrivateKeyStore())
     const key = await kms.createKey({ type: 'Secp256r1' })
     expect(key.type).toEqual('Secp256r1')
@@ -144,7 +175,7 @@ describe('@veramo/kms-local Secp256r1 support', () => {
     })
   })
 
-  it('should import a private key', async () => {
+  it('imports a private key', async () => {
     const kms = new KeyManagementSystem(new MemoryPrivateKeyStore())
     const privateKeyHex = '96fe4d2b4a5d3abc4679fe39aa5d4b76990ff416e6ff403a58bd722cf8352f94'
     const key = await kms.importKey({ kid: 'test', privateKeyHex, type: 'Secp256r1' })
@@ -156,7 +187,7 @@ describe('@veramo/kms-local Secp256r1 support', () => {
     })
   })
 
-  it('should sign input data', async () => {
+  it('signs input data', async () => {
     const kms = new KeyManagementSystem(new MemoryPrivateKeyStore())
     const privateKeyHex = '96fe4d2b4a5d3abc4679fe39aa5d4b76990ff416e6ff403a58bd722cf8352f94'
     const data = stringToUtf8Bytes('test')

--- a/packages/kms-local/src/key-management-system.ts
+++ b/packages/kms-local/src/key-management-system.ts
@@ -71,7 +71,7 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
     return managedKeys
   }
 
-  async createKey({ type }: { type: TKeyType }): Promise<ManagedKeyInfo> {
+  async createKey({ type, kid }: { type: TKeyType, kid?: string }): Promise<ManagedKeyInfo> {
     let key: ManagedKeyInfo
 
     switch (type) {
@@ -80,6 +80,7 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
         const publicKey = ed25519.utils.getExtendedPublicKey(ed25519SecretKey).pointBytes
         key = await this.importKey({
           type,
+          kid,
           privateKeyHex: bytesToHex(concat([ed25519SecretKey, publicKey])),
         })
         break
@@ -89,6 +90,7 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
         const privateBytes = randomBytes(32)
         key = await this.importKey({
           type,
+          kid,
           privateKeyHex: bytesToHex(privateBytes),
         })
         break
@@ -97,6 +99,7 @@ export class KeyManagementSystem extends AbstractKeyManagementSystem {
         const secretX25519 = x25519.utils.randomPrivateKey()
         key = await this.importKey({
           type,
+          kid,
           privateKeyHex: bytesToHex(secretX25519),
         })
         break

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -4,7 +4,7 @@
     "baseUrl": ".",
     "outDir": "./build",
     "rootDir": ".",
-    "types": ["node", "jest"],
+    "types": ["node", "jest"]
   },
   "include": [
     "scripts/**/*",


### PR DESCRIPTION
## What issue is this PR fixing

[An issue was flagged](https://github.com/decentralized-identity/veramo/pull/1490#discussion_r2788078704) in #1490 relating to the handling of `kid` parameters when creating keys. Specifying a `kid` when creating keys could lead to `key-not-found` errors when trying to use that key since the private key store used by `kms-local` would get out of sync with the public key store used by `key-manager`.

This PR fixes that and adds unit and integration tests to check for regressions.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `pnpm i`, `pnpm build`, `pnpm test`, `pnpm test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [X] I added unit tests.
* [X] I added integration tests.
