### PR TITLE
fix(did-comm): add required `apv` protected header when packing JWE messages

### DIFF
--- a/packages/did-comm/src/__tests__/packing.test.ts
+++ b/packages/did-comm/src/__tests__/packing.test.ts
@@ -9,6 +9,8 @@ import { DIDResolverPlugin } from '../../../did-resolver/src'
 import { type DIDDocument, Resolver } from 'did-resolver'
 import { type IDIDComm } from '../types/IDIDComm.js'
 import { base64ToBytes, bytesToUtf8String } from '@veramo/utils'
+import { createHash } from 'node:crypto'
+import { computeApv } from '../utils.js'
 
 const multiBaseDoc = {
   '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/suites/jws-2020/v1'],
@@ -391,6 +393,93 @@ describe('didComm', () => {
           },
         )
       })
+    })
+  })
+
+  describe('apv protected header', () => {
+    // independent implementation of the `apv` definition from
+    // https://identity.foundation/didcomm-messaging/spec/v2.0/#ecdh-es-key-wrapping-and-common-protected-headers
+    const referenceApv = (kids: string[]): string =>
+      createHash('sha256')
+        .update([...kids].sort().join('.'), 'utf8')
+        .digest('base64url')
+
+    const decodeProtectedHeader = (packedMessage: { message: string }) =>
+      JSON.parse(bytesToUtf8String(base64ToBytes(JSON.parse(packedMessage.message).protected)))
+
+    const recipientKids = (packedMessage: { message: string }): string[] =>
+      JSON.parse(packedMessage.message).recipients.map((recipient: any) => recipient.header.kid)
+
+    it('should compute apv as the base64url encoded sha256 of the sorted kid list', () => {
+      const kids = ['did:example:bob#key-2', 'did:example:alice#key-1']
+      expect(computeApv(kids)).toEqual(referenceApv(kids))
+      // sorting is part of the definition, so input order must not matter
+      expect(computeApv(kids)).toEqual(computeApv([...kids].reverse()))
+      // base64url without padding
+      expect(computeApv(kids)).toMatch(/^[A-Za-z0-9_-]+$/)
+    })
+
+    // Note: a successful round trip is itself an assertion that `apv` was also passed to the encrypters.
+    // The protected header is merged into every recipient header before the KEK is computed on decrypt, so
+    // an `apv` that did not participate in the Concat KDF at pack time would yield a different KEK here.
+    describe.each([
+      ['anoncrypt', ['ECDH-ES+A256KW', 'ECDH-ES+XC20PKW']],
+      ['authcrypt', ['ECDH-1PU+A256KW', 'ECDH-1PU+XC20PKW']],
+    ] as const)('%s packing', (packing, algs) => {
+      describe.each(['XC20P', 'A256GCM', 'A256CBC-HS512'])('%s enc', (enc) => {
+        it.each(algs)(`should set apv in the protected header for ${enc} enc and %s alg`, async (alg) => {
+          const message = createTestMessage(recipientDID.did)
+          const packedMessage = await agent.packDIDCommMessage({
+            message,
+            packing: packing as any,
+            options: { enc: enc as any, alg: alg as any },
+          })
+
+          const protectedHeader = decodeProtectedHeader(packedMessage)
+          expect(protectedHeader.apv).toEqual(referenceApv(recipientKids(packedMessage)))
+
+          const unpackedMessage = await agent.unpackDIDCommMessage(packedMessage)
+          expect(unpackedMessage.message).toEqual(message)
+        })
+      })
+    })
+
+    it('should compute apv over all recipients of a multi-recipient message', async () => {
+      const message = { ...createTestMessage(recipientDID.did), to: [recipientDID.did, senderDID.did] }
+      const packedMessage = await agent.packDIDCommMessage({ message, packing: 'anoncrypt' })
+
+      const kids = recipientKids(packedMessage)
+      expect(kids.length).toEqual(2)
+      expect(decodeProtectedHeader(packedMessage).apv).toEqual(referenceApv(kids))
+
+      const unpackedMessage = await agent.unpackDIDCommMessage(packedMessage)
+      expect(unpackedMessage.message).toEqual(message)
+    })
+
+    it('should compute the same apv regardless of the order the recipients are listed in', async () => {
+      const packedMessage = await agent.packDIDCommMessage({
+        message: { ...createTestMessage(recipientDID.did), to: [recipientDID.did, senderDID.did] },
+        packing: 'anoncrypt',
+      })
+      const reversedRecipients = await agent.packDIDCommMessage({
+        message: { ...createTestMessage(recipientDID.did), to: [senderDID.did, recipientDID.did] },
+        packing: 'anoncrypt',
+      })
+
+      expect(decodeProtectedHeader(packedMessage).apv).toEqual(decodeProtectedHeader(reversedRecipients).apv)
+    })
+
+    it('should compute apv over bcc recipients as well', async () => {
+      const message = createTestMessage(recipientDID.did)
+      const packedMessage = await agent.packDIDCommMessage({
+        message,
+        packing: 'anoncrypt',
+        options: { bcc: [senderDID.did] },
+      })
+
+      const kids = recipientKids(packedMessage)
+      expect(kids.length).toEqual(2)
+      expect(decodeProtectedHeader(packedMessage).apv).toEqual(referenceApv(kids))
     })
   })
 })

--- a/packages/did-comm/src/didcomm.ts
+++ b/packages/did-comm/src/didcomm.ts
@@ -60,6 +60,7 @@ import { schema } from './plugin.schema.js'
 import { v4 as uuidv4 } from 'uuid'
 
 import {
+  computeApv,
   createEcdhWrapper,
   extractManagedRecipients,
   extractSenderEncryptionKey,
@@ -270,6 +271,7 @@ export class DIDComm implements IAgentPlugin {
     let protectedHeader: {
       skid?: string
       typ: string
+      apv?: string
     } = {
       typ: DIDCommMessageMediaType.ENCRYPTED,
     }
@@ -363,6 +365,12 @@ export class DIDComm implements IAgentPlugin {
       recipients.push(...(await computeRecipients(to)))
     }
 
+    // 2.4 compute the `apv` protected header, which the DIDComm v2 spec requires for both ECDH-ES and
+    // ECDH-1PU: base64url(sha256(<recipient kids, sorted, joined by '.'>)). It is also fed to the
+    // encrypters so that it participates in the Concat KDF as PartyVInfo.
+    const apv = computeApv(recipients.map((recipient) => recipient.kid))
+    protectedHeader = { ...protectedHeader, apv }
+
     // 3. create Encrypter for each recipient
     const encrypters: Encrypter[] = recipients
       .map((recipient) => {
@@ -375,6 +383,7 @@ export class DIDComm implements IAgentPlugin {
                 <ECDH>senderECDH,
                 {
                   kid: recipient.kid,
+                  apv,
                 },
               )
             } else if (options?.alg?.endsWith('+A256KW')) {
@@ -384,14 +393,15 @@ export class DIDComm implements IAgentPlugin {
                 <ECDH>senderECDH,
                 {
                   kid: recipient.kid,
+                  apv,
                 },
               )
             }
           } else if (args.packing === 'anoncrypt' && (!options.alg || options.alg?.startsWith('ECDH-ES'))) {
             if (options.alg?.endsWith('+XC20PKW')) {
-              return a256gcmAnonEncrypterX25519WithXC20PKW(recipient.publicKeyBytes, recipient.kid)
+              return a256gcmAnonEncrypterX25519WithXC20PKW(recipient.publicKeyBytes, recipient.kid, apv)
             } else if (options?.alg?.endsWith('+A256KW')) {
-              return a256gcmAnonEncrypterX25519WithA256KW(recipient.publicKeyBytes, recipient.kid)
+              return a256gcmAnonEncrypterX25519WithA256KW(recipient.publicKeyBytes, recipient.kid, apv)
             }
           }
         } else if (options.enc === 'A256CBC-HS512') {
@@ -400,18 +410,20 @@ export class DIDComm implements IAgentPlugin {
               // FIXME: the didcomm spec actually links to ECDH-1PU(v4)
               return a256cbcHs512AuthEncrypterX25519WithXC20PKW(recipient.publicKeyBytes, <ECDH>senderECDH, {
                 kid: recipient.kid,
+                apv,
               })
             } else if (options?.alg?.endsWith('+A256KW')) {
               // FIXME: the didcomm spec actually links to ECDH-1PU(v4)
               return a256cbcHs512AuthEncrypterX25519WithA256KW(recipient.publicKeyBytes, <ECDH>senderECDH, {
                 kid: recipient.kid,
+                apv,
               })
             }
           } else if (args.packing === 'anoncrypt' && (!options.alg || options.alg?.startsWith('ECDH-ES'))) {
             if (options.alg?.endsWith('+XC20PKW')) {
-              return a256cbcHs512AnonEncrypterX25519WithXC20PKW(recipient.publicKeyBytes, recipient.kid)
+              return a256cbcHs512AnonEncrypterX25519WithXC20PKW(recipient.publicKeyBytes, recipient.kid, apv)
             } else if (options?.alg?.endsWith('+A256KW')) {
-              return a256cbcHs512AnonEncrypterX25519WithA256KW(recipient.publicKeyBytes, recipient.kid)
+              return a256cbcHs512AnonEncrypterX25519WithA256KW(recipient.publicKeyBytes, recipient.kid, apv)
             }
           }
         } else if (options.enc === 'XC20P') {
@@ -421,19 +433,20 @@ export class DIDComm implements IAgentPlugin {
               return xc20pAuthEncrypterEcdh1PuV3x25519WithXC20PKW(
                 recipient.publicKeyBytes,
                 <ECDH>senderECDH,
-                { kid: recipient.kid },
+                { kid: recipient.kid, apv },
               )
             } else if (options?.alg?.endsWith('+A256KW')) {
               // FIXME: the didcomm spec actually links to ECDH-1PU(v4)
               return xc20pAuthEncrypterEcdh1PuV3x25519WithA256KW(recipient.publicKeyBytes, <ECDH>senderECDH, {
                 kid: recipient.kid,
+                apv,
               })
             }
           } else if (args.packing === 'anoncrypt' && (!options.alg || options.alg?.startsWith('ECDH-ES'))) {
             if (options.alg?.endsWith('+XC20PKW')) {
-              return xc20pAnonEncrypterX25519WithXC20PKW(recipient.publicKeyBytes, recipient.kid)
+              return xc20pAnonEncrypterX25519WithXC20PKW(recipient.publicKeyBytes, recipient.kid, apv)
             } else if (options?.alg?.endsWith('+A256KW')) {
-              return xc20pAnonEncrypterX25519WithA256KW(recipient.publicKeyBytes, recipient.kid)
+              return xc20pAnonEncrypterX25519WithA256KW(recipient.publicKeyBytes, recipient.kid, apv)
             }
           }
         }

--- a/packages/did-comm/src/utils.ts
+++ b/packages/did-comm/src/utils.ts
@@ -5,6 +5,7 @@ import { DIDResolutionOptions, parse as parseDidUrl } from 'did-resolver'
 import Debug from 'debug'
 import {
   _ExtendedVerificationMethod,
+  bytesToBase64url,
   bytesToHex,
   decodeJoseBlob,
   extractPublicKeyHex,
@@ -12,10 +13,24 @@ import {
   isDefined,
   mapIdentifierKeysToDoc,
   resolveDidOrThrow,
+  stringToUtf8Bytes,
 } from '@veramo/utils'
 import { x25519 } from '@noble/curves/ed25519'
+import { sha256 } from '@noble/hashes/sha256'
 
 const debug = Debug('veramo:did-comm:action-handler')
+
+/**
+ * Computes the `apv` JWE protected header value for a DIDComm v2 message.
+ *
+ * The DIDComm messaging spec defines it, for both ECDH-ES and ECDH-1PU, as the base64url (no padding)
+ * encoding of the SHA-256 hash of the alphanumerically sorted recipient `kid` list, concatenated with `.`.
+ *
+ * @param kids - the `kid` of every recipient of the message
+ */
+export function computeApv(kids: string[]): string {
+  return bytesToBase64url(sha256(stringToUtf8Bytes([...kids].sort().join('.'))))
+}
 
 export function createEcdhWrapper(secretKeyRef: string, context: IAgentContext<IKeyManager>): ECDH {
   return async (theirPublicKey: Uint8Array): Promise<Uint8Array> => {


### PR DESCRIPTION
Fixes #1500

## Problem

`packDIDCommMessageJWE()` never computes `apv`. The JWE protected header of both anoncrypt and authcrypt envelopes contains only `alg`, `typ`, `epk`, `enc` (plus `skid` for authcrypt). Strict DIDComm v2 implementations treat `apv` as a required protected-header field and reject the envelope during parsing, before any decryption is attempted — e.g. didcomm-rust fails with:

```
DIDCommMalformed: Malformed: Unable parse protected header: missing field `apv` at line 1 column 166
```

The [DIDComm v2 spec](https://identity.foundation/didcomm-messaging/spec/v2.0/#ecdh-es-key-wrapping-and-common-protected-headers) defines it identically for ECDH-ES and ECDH-1PU:

> `apv`: this represents the recipients' `kid` list. The list must be alphanumerically sorted, `kid` values will then be concatenated with a `.` and the final result MUST be base64 URL (no padding) encoding of the SHA256 hash of concatenated list.

## Changes

- New `computeApv(kids)` helper in `packages/did-comm/src/utils.ts` implementing the spec definition.
- `packDIDCommMessageJWE()` computes `apv` over all recipients (including `bcc`) once the recipient list is known, adds it to the protected header, and passes it to **every** encrypter so it also participates in the Concat KDF as PartyVInfo.

The low-level layer needed no changes — every encrypter in `a256kw-encrypters.ts` / `xc20pkw-encrypters.ts` already accepted an optional `apv` and forwarded it through `createFullEncrypter()`. Only the 12 call sites were passing it.

## Compatibility

`decryptJWE()` in did-jwt >= 7 merges the protected header into each recipient header before computing the KEK, so receivers on current did-jwt derive the same key and can still decrypt envelopes that carry `apv`. All existing pack/unpack round-trip tests pass unchanged.

## Tests

Added an `apv protected header` suite to `packing.test.ts`:

- `computeApv` checked against an independent `node:crypto` implementation, including sort-order independence and the no-padding base64url alphabet.
- A 12-case matrix over {anoncrypt, authcrypt} × {XC20P, A256GCM, A256CBC-HS512} × both key-wrap algs, asserting the protected header `apv` matches the hash of the actual recipient `kid`s — one case per encrypter call site touched.
- Multi-recipient and `bcc` coverage, plus recipient-order independence.

Note that a successful round trip is itself an assertion that `apv` reached the encrypters: since the protected header is merged into every recipient header on decrypt, an `apv` that did not participate in the KDF at pack time yields a different KEK. Dropping `apv` from a single encrypter call locally fails 5 tests, confirming the matrix is not vacuous.

`pnpm jest packages/did-comm` — 170 passed. `__tests__/localAgent.test.ts` — 219 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)